### PR TITLE
rename 4 consts to flag_NNNN; format src; small optimize

### DIFF
--- a/src/RegExpr.pas
+++ b/src/RegExpr.pas
@@ -1524,26 +1524,28 @@ begin
 end;
 {$ENDIF}
 
-
 function TRegExpr.IsWordChar(AChar: REChar): Boolean;
 begin
-  Result := Pos(AChar, fWordChars)>0;
+  Result := Pos(AChar, fWordChars) > 0;
   {$IFDEF UnicodeWordDetection}
-  If Not Result and UseUnicodeWordDetection then
-    Result:=IsUnicodeWordChar(aChar);
+  if not Result and UseUnicodeWordDetection then
+    Result := IsUnicodeWordChar(aChar);
   {$ENDIF}
 end;
 
-
 function TRegExpr.IsSpaceChar(AChar: PRegExprChar): Boolean;
 begin
-  Result:=Pos(AChar^,fSpaceChars)>0;
+  Result := Pos(AChar^, fSpaceChars) > 0;
 end;
 
 function TRegExpr.IsDigit(AChar: PRegExprChar): Boolean;
 begin
-  // Avoid Unicode char-> ansi char conversion in case of unicode regexp.
-  Result:=Ord(AChar^) in [Ord('0')..Ord('9')]
+  case AChar^ of
+    '0'..'9':
+      Result := True;
+    else
+      Result := False;
+  end;
 end;
 
 procedure TRegExpr.InvalidateProgramm;


### PR DESCRIPTION
rename 4 too generic names
```
 HASWIDTH =   01; // Known never to match nil string.
 SIMPLE   =   02; // Simple enough to be STAR/PLUS/BRACES operand.
 SPSTART  =   04; // Starts with * or +.
 WORST    =   0;  // Worst case.
```
to
```
 flag_HasWidth  = 01; // Known never to match nil string.
 flag_Simple    = 02; // Simple enough to be STAR/PLUS/BRACES operand.
 flag_SpecStart = 04; // Starts with * or +.
 flag_Worst     =  0; // Worst case.
```