### PR TITLE
Remove wrong inlines directives which break Delphi compatibility

### DIFF
--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -438,7 +438,6 @@ type
 
     // emit back-reference to group
     function EmitGroupRef(AIndex: integer; AIgnoreCase: boolean): PRegExprChar;
-      {$IFDEF InlineFuncs}inline;{$ENDIF}
 
     {$IFDEF FastUnicodeData}
     procedure FindCategoryName(var scan: PRegExprChar; var ch1, ch2: REChar);
@@ -5677,7 +5676,7 @@ var
     APtr := p;
   end;
 
-  procedure FindSubstGroupIndex(var p: PRegExprChar; var Idx: integer); {$IFDEF InlineFuncs}inline;{$ENDIF}
+  procedure FindSubstGroupIndex(var p: PRegExprChar; var Idx: integer);
   begin
     Idx := ParseVarName(p);
     if (Idx >= 0) and (Idx <= High(GrpIndexes)) then


### PR DESCRIPTION
FPC is not strict enough but that could change any time.
FPC devs also say that the inline directive should not be used as the compiler knows better when to inline and when not