### PR TITLE
Implement `SetInputSubString`. Issue #299

### DIFF
--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -6975,7 +6975,7 @@ begin
     exit;
 
   fInputString := AInputString;
-  UniqueString(fInputString);
+  //UniqueString(fInputString);
 
   fInputStart := PRegExprChar(fInputString) + AInputStartPos - 1;
   fInputEnd := fInputStart + AInputLen;

--- a/test/tests.pas
+++ b/test/tests.pas
@@ -1248,6 +1248,13 @@ procedure TTestRegexpr.RunRETest(aIndex: Integer);
 var
   T: TRegExTest;
   S: RegExprString;
+
+  procedure DoMatchAssertions;
+  begin
+    AreEqual('Search position', T.MatchStart, RE.MatchPos[0]);
+    AreEqual('Matched text', PrintableString(T.ExpectedResult), PrintableString(RE.Match[0]));
+  end;
+
 begin
   T:= testCases[aIndex];
 {$IFDEF DUMPTESTS}
@@ -1262,8 +1269,17 @@ begin
   else
   begin
     RE.Exec(T.inputText);
-    AreEqual('Search position', T.MatchStart, RE.MatchPos[0]);
-    AreEqual('Matched text', PrintableString(T.ExpectedResult), PrintableString(RE.Match[0]));
+    DoMatchAssertions;
+
+    // Test via InputString
+    RE.InputString := T.InputText;
+    RE.Exec;
+    DoMatchAssertions;
+
+    // Test via SetInputSubString
+    RE.SetInputSubString('abc' + T.InputText + '12345', 4, Length(t.InputText));
+    RE.Exec;
+    DoMatchAssertions;
   end;
 end;
 


### PR DESCRIPTION
Please review. / See issue #299

1) I wasn't sure if `property InputString` should be modified, so it only returns the sub-string?

2) Since `fInputString` may contain extra text, I replaced all references to it.

3) I added `strLpos` for the lookup in p(wide)char, with a given max len. To further optimize I can add a `strLScan` (copied from fpc sources), and amend it to have a length param. Currently it simply checks the result, if it has gone to far. 

1 & 3 => depend on feedback.
