### PR TITLE
Fix loop index #307

### DIFF
--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -5605,6 +5605,7 @@ begin
   // will lead to leaving ExecPrim without actual search. That is
   // important for ExecNext logic and so on.
   ClearMatches;
+  IsMatchingAfterLoop := False;
 
   // Don't check IsProgrammOk here! it causes big slowdown in test_benchmark!
   if programm = nil then

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -5237,7 +5237,9 @@ begin
                 regInput := save;
               end;
               Dec(LoopStackIdx); // Fail. May be we are too greedy? ;)
+              no := LoopStackIdx;
               Result := MatchPrim(next);
+              LoopStackIdx := no;
               if not Result then
                 regInput := save;
               Exit;
@@ -5245,7 +5247,9 @@ begin
             else
             begin
               // non-greedy - try just now
+              no := LoopStackIdx;
               Result := MatchPrim(next);
+              LoopStackIdx := no;
               if Result then
                 Exit
               else

--- a/test/tests.pas
+++ b/test/tests.pas
@@ -129,6 +129,8 @@ type
     procedure RunTest72;
     procedure RunTest73;
     procedure RunTest74;
+    procedure RunTest75;
+    procedure RunTest76;
   end;
 
 implementation
@@ -162,7 +164,7 @@ end;
 
 
 const
-  testCases: array [1 .. 74] of TRegExTest = (
+  testCases: array [1 .. 76] of TRegExTest = (
     // 1
     (
     expression: '\nd';
@@ -754,6 +756,22 @@ const
     substitutionText: '';
     expectedResult: 'Acecegg_a';
     matchStart: 9
+    ),
+    // 75
+    ( // nested loops
+    expression: 'A((ce+?)c?|ce)*a';
+    inputText: 'Aceecea_';
+    substitutionText: '';
+    expectedResult: 'Aceecea';
+    matchStart: 1
+    ),
+    // 76
+    ( // nested loops
+    expression: 'A(?>(?:b|c(?:d|e(?:f|g){0,2}?){1,1}?){2,2}?_)a';
+    inputText: 'Acece_x_Acecegg_a_';
+    substitutionText: '';
+    expectedResult: 'Acecegg_a';
+    matchStart: 9
     )
   );
 
@@ -1235,6 +1253,15 @@ begin
   RunRETest(74);
 end;
 
+procedure TTestRegexpr.RunTest75;
+begin
+  RunRETest(75);
+end;
+
+procedure TTestRegexpr.RunTest76;
+begin
+  RunRETest(76);
+end;
 
 procedure TTestRegexpr.TestGroups;
 var

--- a/test/tests.pas
+++ b/test/tests.pas
@@ -127,6 +127,8 @@ type
     procedure RunTest70;
     procedure RunTest71;
     procedure RunTest72;
+    procedure RunTest73;
+    procedure RunTest74;
   end;
 
 implementation
@@ -160,7 +162,7 @@ end;
 
 
 const
-  testCases: array [1 .. 72] of TRegExTest = (
+  testCases: array [1 .. 74] of TRegExTest = (
     // 1
     (
     expression: '\nd';
@@ -736,6 +738,22 @@ const
     substitutionText: '';
     expectedResult: '12344321';
     matchStart: 8
+    ),
+    // 73
+    ( // nested loops / OP_LOOPNG
+    expression: 'A(?>(?:b|c(?:d|e)*?)*?_)a';
+    inputText: 'Acece_x_Acece_a_';
+    substitutionText: '';
+    expectedResult: 'Acece_a';
+    matchStart: 9
+    ),
+    // 74
+    ( // nested loops / OP_LOOPNG
+    expression: 'A(?>(?:b|c(?:d|e(?:f|g)*?)*?)*?_)a';
+    inputText: 'Acece_x_Acecegg_a_';
+    substitutionText: '';
+    expectedResult: 'Acecegg_a';
+    matchStart: 9
     )
   );
 
@@ -1205,6 +1223,16 @@ end;
 procedure TTestRegexpr.RunTest72;
 begin
   RunRETest(72);
+end;
+
+procedure TTestRegexpr.RunTest73;
+begin
+  RunRETest(73);
+end;
+
+procedure TTestRegexpr.RunTest74;
+begin
+  RunRETest(74);
 end;
 
 


### PR DESCRIPTION
Fix for issue #307
See issue for description/reason of changes.

Missing entries in history.txt => this depend on order of merging compared with other merge requests.

Incudes unrelated addition, to allow `RE.Dump` display loops and open/close with indent.