### PR TITLE
Fix loop new / for issue #307

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -11,6 +11,7 @@
   of the inner loop.
  -=- (^) Removed limit "LoopStackMax = 10" for nested loops (OP_LOOP)
  -=- (^) Added indent for RegEx.Dump()
+ -=- (^) Detect fixed length for in branches, if all paths are of equal length.
   By Martin Friebe.
 
  v. 1.161 2023.08.17

--- a/History.txt
+++ b/History.txt
@@ -6,6 +6,13 @@
                                      (-) - bugfix
                                      (^) - improvement
 
+ v. 1.162 2023.08.21
+ -=- (-) Fix nested loops using OP_LOOP. Outer loops were run with the counter
+  of the inner loop.
+ -=- (^) Removed limit "LoopStackMax = 10" for nested loops (OP_LOOP)
+ -=- (^) Added indent for RegEx.Dump()
+  By Martin Friebe.
+
  v. 1.161 2023.08.17
  -=- (-) Fix atomic groups. Allow backtracking the entire group.
   Make '*','+',... operators aware of the atomic behaviour. Allow nesting.

--- a/History.txt
+++ b/History.txt
@@ -12,6 +12,7 @@
  -=- (^) Removed limit "LoopStackMax = 10" for nested loops (OP_LOOP)
  -=- (^) Added indent for RegEx.Dump()
  -=- (^) Detect fixed length for in branches, if all paths are of equal length.
+ -=- (^) Optimization, detect more anchors: ^ \G $ .*
   By Martin Friebe.
 
  v. 1.161 2023.08.17

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -3006,12 +3006,18 @@ begin
       if PREOp(scan)^ = OP_CONTINUE_POS then
         regAnchored := raContinue
       else
+      // ".*", ".*?", ".*+" at the very start of the pattern, only need to be
+      // tested from the start-pos of the InputString.
+      // If a pattern matches, then the ".*" will always go forward to where the
+      // rest of the pattern starts matching
+      // OP_ANY is "ModifierS=True"
       if (PREOp(scan)^ = OP_STAR) or (PREOp(scan)^ = OP_STARNG) or (PREOp(scan)^ = OP_STAR_POSS) then begin
         scanTemp := AlignToInt(scan + REOpSz + RENextOffSz);
         if PREOp(scanTemp)^ = OP_ANY then
           regAnchored := raOnlyOnce;
       end
       else
+      // "{0,} is the same as ".*". So the same optimization applies
       if (PREOp(scan)^ = OP_BRACES) or (PREOp(scan)^ = OP_BRACESNG) or (PREOp(scan)^ = OP_BRACES_POSS) then begin
         scanTemp := AlignToInt(scan + REOpSz + RENextOffSz);
         if (PREBracesArg(scanTemp)^ = 0) and (PREBracesArg(scanTemp + REBracesArgSz)^ = MaxBracesArg) then begin

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -5297,12 +5297,16 @@ begin
                 Result := MatchPrim(opnd);
                 if Result then
                   Exit;
+                if IsBacktrackingGroupAsAtom then
+                  Exit;
                 Dec(Local.LoopInfoListPtr^.Count);
                 regInput := save;
               end;
               CurrentLoopInfoListPtr := Local.LoopInfoListPtr^.OuterLoop;
               Result := MatchPrim(next);
               CurrentLoopInfoListPtr := Local.LoopInfoListPtr;
+              if IsBacktrackingGroupAsAtom then
+                Exit;
               if not Result then
                 regInput := save;
               Exit;
@@ -5315,12 +5319,16 @@ begin
               CurrentLoopInfoListPtr := Local.LoopInfoListPtr;
               if Result then
                 Exit;
+              if IsBacktrackingGroupAsAtom then
+                Exit;
               regInput := save; // failed - move next and try again
               if Local.LoopInfoListPtr^.Count < BracesMax then
               begin
                 Inc(Local.LoopInfoListPtr^.Count);
                 Result := MatchPrim(opnd);
                 if Result then
+                  Exit;
+                if IsBacktrackingGroupAsAtom then
                   Exit;
                 Dec(Local.LoopInfoListPtr^.Count);
                 regInput := save;
@@ -5333,6 +5341,8 @@ begin
             Inc(Local.LoopInfoListPtr^.Count);
             Result := MatchPrim(opnd);
             if Result then
+              Exit;
+            if IsBacktrackingGroupAsAtom then
               Exit;
             Dec(Local.LoopInfoListPtr^.Count);
             regInput := save;

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -3020,7 +3020,9 @@ begin
       // "{0,} is the same as ".*". So the same optimization applies
       if (PREOp(scan)^ = OP_BRACES) or (PREOp(scan)^ = OP_BRACESNG) or (PREOp(scan)^ = OP_BRACES_POSS) then begin
         scanTemp := AlignToInt(scan + REOpSz + RENextOffSz);
-        if (PREBracesArg(scanTemp)^ = 0) and (PREBracesArg(scanTemp + REBracesArgSz)^ = MaxBracesArg) then begin
+        if (PREBracesArg(scanTemp)^ = 0)  // BracesMinCount
+        and (PREBracesArg(scanTemp + REBracesArgSz)^ = MaxBracesArg)  // BracesMaxCount
+        then begin
           scanTemp := AlignToPtr(scanTemp + REBracesArgSz + REBracesArgSz);
           if PREOp(scanTemp)^ = OP_ANY then
             regAnchored := raOnlyOnce;

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -518,6 +518,9 @@ type
     {$IFDEF UseFirstCharSet} // ###0.929
     procedure FillFirstCharSet(prog: PRegExprChar);
     {$ENDIF}
+
+    function IsPartFixedLength(var prog: PRegExprChar; var op: TREOp; var ALen: integer; StopAt: TREOp): boolean; overload;
+
     { ===================== Matching section =================== }
     // repeatedly match something simple, report how many
     function FindRepeated(p: PRegExprChar; AMax: integer): integer;
@@ -661,7 +664,6 @@ type
 
     // Opcode contains only operations for fixed match length: EXACTLY*, ANY*, etc
     function IsFixedLength(var op: TREOp; var ALen: integer): boolean; overload;
-    function IsPartFixedLength(var prog: PRegExprChar; var op: TREOp; var ALen: integer; StopAt: TREOp): boolean; overload;
 
     // Regular expression.
     // For optimization, TRegExpr will automatically compiles it into 'P-code'

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -652,7 +652,7 @@ type
 
     {$IFDEF RegExpPCodeDump}
     // Show compiled regex in textual form
-    function Dump: RegExprString;
+    function Dump(Indent: Integer = 0): RegExprString;
     // Show single opcode in textual form
     function DumpOp(op: TREOp): RegExprString;
     {$ENDIF}
@@ -6692,13 +6692,13 @@ begin
   Result := Result + '} ';
 end;
 
-function TRegExpr.Dump: RegExprString;
+function TRegExpr.Dump(Indent: Integer): RegExprString;
 // dump a regexp in vaguely comprehensible form
 var
   s: PRegExprChar;
   op: TREOp; // Arbitrary non-END op.
   next: PRegExprChar;
-  i, NLen: integer;
+  i, NLen, CurIndent: integer;
   Diff: PtrInt;
   iByte: byte;
   ch, ch2: REChar;
@@ -6706,13 +6706,18 @@ begin
   if not IsProgrammOk then
     Exit;
 
+  CurIndent := 0;
   op := OP_EXACTLY;
   Result := '';
   s := regCodeWork;
   while op <> OP_EEND do
   begin // While that wasn't END last time...
     op := s^;
-    Result := Result + Format('%2d: %s', [s - programm, DumpOp(s^)]);
+    if (((op >=OP_CLOSE_FIRST) and (op <= OP_CLOSE_LAST)) or (op = OP_LOOP) or (op = OP_LOOPNG)) and (CurIndent > 0) then
+      dec(CurIndent, Indent);
+    Result := Result + Format('%2d:%s %s', [s - programm, StringOfChar(' ', CurIndent), DumpOp(s^)]);
+    if (((op >=OP_OPEN_FIRST) and (op <= OP_OPEN_LAST)) or (op = OP_LOOPENTRY)) then
+      inc(CurIndent, Indent);
     // Where, what.
     next := regNext(s);
     if next = nil // Next ptr.

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -257,7 +257,7 @@ type
   end;
   TRegExprCharCheckerInfos = array of TRegExprCharCheckerInfo;
 
-  TRegExAncho = (
+  TRegExAnchor = (
     raNone,     // Not anchored
     raBOL,      // Must start at BOL
     raEOL,      // Must start at EOL (maybe look behind)
@@ -309,7 +309,7 @@ type
     // to execute that permits the execute phase to run lots faster on
     // simple cases.
 
-    regAnchored: TRegExAncho; // is the match anchored (at beginning-of-line only)?
+    regAnchored: TRegExAnchor; // is the match anchored (at beginning-of-line only)?
     // regAnchored permits very fast decisions on suitable starting points
     // for a match, cutting down the work a lot. regMust permits fast rejection
     // of lines that cannot possibly match. The regMust tests are costly enough

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -527,7 +527,7 @@ type
     procedure FillFirstCharSet(prog: PRegExprChar);
     {$ENDIF}
 
-    function IsPartFixedLength(var prog: PRegExprChar; var op: TREOp; var ALen: integer; StopAt: TREOp): boolean; overload;
+    function IsPartFixedLength(var prog: PRegExprChar; var op: TREOp; var ALen: integer; StopAt: TREOp): boolean;
 
     { ===================== Matching section =================== }
     // repeatedly match something simple, report how many
@@ -671,7 +671,7 @@ type
     function IsCompiled: boolean; {$IFDEF InlineFuncs}inline;{$ENDIF}
 
     // Opcode contains only operations for fixed match length: EXACTLY*, ANY*, etc
-    function IsFixedLength(var op: TREOp; var ALen: integer): boolean; overload;
+    function IsFixedLength(var op: TREOp; var ALen: integer): boolean;
 
     // Regular expression.
     // For optimization, TRegExpr will automatically compiles it into 'P-code'

--- a/test/tests.pas
+++ b/test/tests.pas
@@ -1150,6 +1150,18 @@ begin
              );
 
 
+  IsMatching('atomic nested {} no greedy / no branches',
+             '(?:(?>Aa(y){3,4}?)|.*)B',
+             'AayyyyBB',   [1,8,   -1,-1] ); // 40 y
+  IsMatching('NOT atomic nested {} no greedy / no branches', // ensure non-atomic has different result
+             '(?:(?:Aa(y){3,4}?)|.*)B',
+             'AayyyyBB',   [1,7,   6,1] ); // 40 y
+
+  IsMatching('atomic nested {} no greedy ',
+             '(?:(?>Aa(x|y(x|y(x|y){3,4}?){3,4}?){3,4}?)|.*)B',
+             'AayyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyBB',   [1,44,   -1,-1, -1,-1, -1,-1] ); // 40 y
+
+
 end;
 
 procedure TTestRegexpr.RunTest1;

--- a/test/tests.pas
+++ b/test/tests.pas
@@ -1335,18 +1335,34 @@ begin
 
   for i := low(TestOnlyOnceData) to high(TestOnlyOnceData) do begin
     s := TestOnlyOnceData[i];
+    RE.ModifierS := True;
     HasAnchor('', s, raOnlyOnce);
     HasAnchor('', s+'a', raOnlyOnce);
     HasAnchor('', s+'|a', raNone);
     HasAnchor('', '('+s+'|a)', raNone);
+    RE.ModifierS := False;
+    if i <> 1 then begin    // {0,}+ possesive not allowed
+      HasAnchor('', s, raNone);
+      HasAnchor('', s+'a', raNone);
+      HasAnchor('', s+'|a', raNone);
+      HasAnchor('', '('+s+'|a)', raNone);
+    end;
   end;
 
   for i := low(TestNotOnlyOnceData) to high(TestNotOnlyOnceData) do begin
     s := TestNotOnlyOnceData[i];
+    RE.ModifierS := True;
     HasAnchor('', s, raNone);
     HasAnchor('', s+'a', raNone);
     HasAnchor('', s+'|a', raNone);
     HasAnchor('', '('+s+'|a)', raNone);
+    RE.ModifierS := False;
+    if (i <> 1) and (i <> 4) then begin
+      HasAnchor('', s, raNone);
+      HasAnchor('', s+'a', raNone);
+      HasAnchor('', s+'|a', raNone);
+      HasAnchor('', '('+s+'|a)', raNone);
+    end;
   end;
 
 


### PR DESCRIPTION
Fix for issue #307  / replaces pull request #311

For base information why the old concept (LoopStack) was entirely replaced: https://github.com/andgineer/TRegExpr/issues/307#issuecomment-1685353441

1) This PR contains an unrelated commit => feature to indent `re.dump()`

2) There no longer is a limit for nested loop. (Except the size of the CUP' stack)

3) `record` in locals of `MatchPrim`
```
function TRegExpr.MatchPrim(prog: PRegExprChar): boolean;
var
  ...
  Local: record
    case TREOp of
      {$IFDEF ComplexBraces}
      OP_LOOPENTRY: (
        LoopInfo: TOpLoopInfo;
      );
      OP_LOOP: ( // and OP_LOOPNG
```
Each of those vars is only used by the give OP. Since `MatchPrim` can be called in very deep recursion, this keeps the size of each frame smaller. (This can be extended to other locals already existing).

4) `OP_STAR, OP_PLUS` old code `System.Move(LoopStack`
There was code backing up the LoopStack. (unclear origin, not in git blame)
It is no longer needed:
- LOOP code now always restores the correct state when backtracking.
- There is no limit for nested loops (though the code did not extend this, as it did not reset `LoopStackIdx`)

5) Tests passing :)