### PR TITLE
Fix recursion

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -6,11 +6,16 @@
                                      (-) - bugfix
                                      (^) - improvement
 
- v. 1.166 2023.09.13
+ v. 1.167 2023.09.13
  -=- (+) Added Exec(AOffset, AMatchMustStartBefore: integer)
   Limit the search for the first matched position to AMatchMustStartBefore
+ -=- (+) Added named group syntax: (?<name>regex)
+ -=- (+) Added named group reference/call syntax with \g and \k
+ -=- (^) Allow underscore in named group name
  -=- (-) Fixed recursive calls accessing outer captures
  -=- (^) Improved speed by reducing clean-up before each match execution
+ -=- (-) Fixed literal brace "{" after quantifier.
+  By Martin Friebe.
 
  v. 1.165 2023.09.08
  -=- (+) Added support for \R (any unicode line break).

--- a/History.txt
+++ b/History.txt
@@ -6,6 +6,12 @@
                                      (-) - bugfix
                                      (^) - improvement
 
+ v. 1.166 2023.09.13
+ -=- (+) Added Exec(AOffset, AMatchMustStartBefore: integer)
+  Limit the search for the first matched position to AMatchMustStartBefore
+ -=- (-) Fixed recursive calls accessing outer captures
+ -=- (^) Improved speed by reducing clean-up before each match execution
+
  v. 1.165 2023.09.08
  -=- (+) Added support for \R (any unicode line break).
   by Alexey Torgashin.

--- a/docs/regular_expressions.rst
+++ b/docs/regular_expressions.rst
@@ -428,14 +428,18 @@ The entire regex has index 0.
 Backreferences
 --------------
 
-Meta-chars ``\1`` through ``\9`` are interpreted as backreferences to groups.
+Meta-chars ``\1`` through ``\9`` are interpreted as backreferences to capture groups.
 They match the previously found group with the specified index.
+
+The meta char ``\g`` followed by a number is also interpreted as backreferences to capture groups. It can be followed by a multi-digit number.
+
 
 =========== ============================
 RegEx       Matches
 =========== ============================
 ``(.)\1+``  ``aaaa`` and ``cc``
 ``(.+)\1+`` also ``abab`` and ``123123``
+``(.)\g1+`` ``aaaa`` and ``cc``
 =========== ============================
 
 RegEx ``(['"]?)(\d+)\1`` matches ``"13"`` (in double quotes), or ``'4'`` (in
@@ -444,11 +448,22 @@ single quotes) or ``77`` (without quotes) etc.
 Named Groups and Backreferences
 -------------------------------
 
-To make some group named, use this syntax: ``(?P<name>expr)``. Also Perl syntax is supported: ``(?'name'expr)``.
+To make some group named, use this syntax: ``(?P<name>expr)``. Also Perl syntax is supported: ``(?'name'expr)``. And further: ``(?<name>expr)``
 
 Name of group must be valid identifier: first char is letter or "_", other chars are alphanumeric or "_". All named groups are also usual groups and share the same numbers 1 to 9.
 
-Backreferences to named groups are ``(?P=name)``, the numbers ``\1`` to ``\9`` can also be used.
+Backreferences to named groups are ``(?P=name)``, the numbers ``\1`` to ``\9`` can also be used. As well as the example ``\g`` and ``\k`` in the table below.
+
+Supported syntax are
+==========================
+``(?P=name)``
+``\g{name}``
+``\k{name}``
+``\k<name>``
+``\k'name'``
+==========================
+
+Example
 
 ========================== ============================
 RegEx                      Matches
@@ -676,6 +691,16 @@ Subroutine calls
 Syntax for call to numbered groups: ``(?1)`` ... ``(?90)`` (maximal index is limited by code).
 
 Syntax for call to named groups: ``(?P>name)``. Also Perl syntax is supported: ``(?&name)``.
+
+Supported syntax are
+==========================
+``(?number)``
+``(?P>name)``
+``(?&name)``
+``\g<name>``
+``\g'name'``
+==========================
+
 
 This is like recursion but calls only code of capturing group with specified index.
 

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -303,6 +303,7 @@ type
     FAllowBraceWithoutMin: boolean;
     FAllowUnsafeLookBehind: boolean;
     FAllowLiteralBraceWithoutRange: boolean;
+    FMatchesCleared: Boolean;
     GrpBounds: TRegExprBoundsArray;
     GrpIndexes: array [0 .. RegexMaxGroups - 1] of integer; // map global group index to _capturing_ group index
     GrpNames: array [0 .. RegexMaxGroups - 1] of RegExprString; // names of groups, if non-empty
@@ -6026,6 +6027,9 @@ end;
 
 procedure TRegExpr.ClearMatches;
 begin
+  if FMatchesCleared then
+    exit;
+  FMatchesCleared := True;
   FillChar(GrpBounds[0].GrpStart, SizeOf(GrpBounds[0].GrpStart[0])*regNumBrackets, 0);
   FillChar(GrpBounds[0].GrpEnd,   SizeOf(GrpBounds[0].GrpEnd[0])  *regNumBrackets, 0);
   FillChar(GrpSubCalled[0], SizeOf(GrpSubCalled[0])*regNumBrackets, 0);
@@ -6110,6 +6114,7 @@ begin
       if StrLPos(fInputStart, PRegExprChar(regMustString), fInputEnd - fInputStart, length(regMustString)) = nil then
         exit;
 
+  FMatchesCleared := False;
   // ATryOnce or anchored match (it needs to be tried only once).
   if (ATryMatchOnlyStartingBefore = AOffset + 1) or (regAnchored in [raBOL, raOnlyOnce, raContinue]) then
   begin

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -889,7 +889,7 @@ uses
 const
   // TRegExpr.VersionMajor/Minor return values of these constants:
   REVersionMajor = 1;
-  REVersionMinor = 165;
+  REVersionMinor = 166;
 
   OpKind_End = REChar(1);
   OpKind_MetaClass = REChar(2);

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -6015,7 +6015,7 @@ begin
           if regRecursion < RegexMaxRecursion then
           begin
             Inc(regRecursion);
-            FillChar(GrpBounds[regRecursion].GrpStart, SizeOf(GrpBounds[0].GrpStart[regRecursion])*regNumBrackets, 0);
+            FillChar(GrpBounds[regRecursion].GrpStart[0], SizeOf(GrpBounds[regRecursion].GrpStart[0])*regNumBrackets, 0);
             bound1 := MatchPrim(regCodeWork);
             Dec(regRecursion);
           end
@@ -6037,7 +6037,7 @@ begin
             saveSubCalled := GrpSubCalled[no];
             GrpSubCalled[no] := True;
             Inc(regRecursion);
-            FillChar(GrpBounds[regRecursion].GrpStart, SizeOf(GrpBounds[0].GrpStart[regRecursion])*regNumBrackets, 0);
+            FillChar(GrpBounds[regRecursion].GrpStart[0], SizeOf(GrpBounds[regRecursion].GrpStart[0])*regNumBrackets, 0);
             bound1 := MatchPrim(save);
             Dec(regRecursion);
             GrpSubCalled[no] := saveSubCalled;
@@ -6137,7 +6137,7 @@ begin
   if FMatchesCleared then
     exit;
   FMatchesCleared := True;
-  FillChar(GrpBounds[0].GrpStart, SizeOf(GrpBounds[0].GrpStart[0])*regNumBrackets, 0);
+  FillChar(GrpBounds[0].GrpStart[0], SizeOf(GrpBounds[0].GrpStart[0])*regNumBrackets, 0);
 end;
 
 procedure TRegExpr.ClearInternalExecData;

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -6138,13 +6138,13 @@ begin
     exit;
   FMatchesCleared := True;
   FillChar(GrpBounds[0].GrpStart, SizeOf(GrpBounds[0].GrpStart[0])*regNumBrackets, 0);
-  FillChar(GrpSubCalled[0], SizeOf(GrpSubCalled[0])*regNumBrackets, 0);
 end;
 
 procedure TRegExpr.ClearInternalExecData;
 begin
   fLastError := reeOk;
   FillChar(GrpBacktrackingAsAtom[0], SizeOf(GrpBacktrackingAsAtom[0])*regNumBrackets, 0);
+  FillChar(GrpSubCalled[0], SizeOf(GrpSubCalled[0])*regNumBrackets, 0);
   IsBacktrackingGroupAsAtom := False;
   {$IFDEF ComplexBraces}
   // no loops started

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -7553,12 +7553,12 @@ begin
     AInputStartPos := 1
   else
   if AInputStartPos > Length(AInputString) then
-    AInputStartPos := Length(AInputString);
+    AInputStartPos := Length(AInputString) + 1;
+  if AInputLen < 0 then
+    AInputLen := 0
+  else
   if AInputLen > Length(AInputString) + 1 - AInputStartPos then
     AInputLen := Length(AInputString) + 1 - AInputStartPos;
-
-  if AInputLen < 1 then
-    exit;
 
   fInputString := AInputString;
   //UniqueString(fInputString);

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -2012,7 +2012,9 @@ function TRegExpr.GetMatch(Idx: integer): RegExprString;
 begin
   Result := '';
   Idx := GrpIndexes[Idx];
-  if (Idx >= 0) and (GrpBounds[0].GrpEnd[Idx] > GrpBounds[0].GrpStart[Idx]) then
+  if (Idx >= 0) and (GrpBounds[0].GrpStart[Idx] <> nil) and
+     (GrpBounds[0].GrpEnd[Idx] > GrpBounds[0].GrpStart[Idx])
+  then
     SetString(Result, GrpBounds[0].GrpStart[Idx], GrpBounds[0].GrpEnd[Idx] - GrpBounds[0].GrpStart[Idx]);
 end; { of function TRegExpr.GetMatch
   -------------------------------------------------------------- }
@@ -6008,7 +6010,6 @@ begin
           begin
             Inc(regRecursion);
             FillChar(GrpBounds[regRecursion].GrpStart, SizeOf(GrpBounds[0].GrpStart[regRecursion])*regNumBrackets, 0);
-            FillChar(GrpBounds[regRecursion].GrpEnd,   SizeOf(GrpBounds[0].GrpEnd[regRecursion])  *regNumBrackets, 0);
             bound1 := MatchPrim(regCodeWork);
             Dec(regRecursion);
           end
@@ -6031,7 +6032,6 @@ begin
             GrpSubCalled[no] := True;
             Inc(regRecursion);
             FillChar(GrpBounds[regRecursion].GrpStart, SizeOf(GrpBounds[0].GrpStart[regRecursion])*regNumBrackets, 0);
-            FillChar(GrpBounds[regRecursion].GrpEnd,   SizeOf(GrpBounds[0].GrpEnd[regRecursion])  *regNumBrackets, 0);
             bound1 := MatchPrim(save);
             Dec(regRecursion);
             GrpSubCalled[no] := saveSubCalled;
@@ -6132,7 +6132,6 @@ begin
     exit;
   FMatchesCleared := True;
   FillChar(GrpBounds[0].GrpStart, SizeOf(GrpBounds[0].GrpStart[0])*regNumBrackets, 0);
-  FillChar(GrpBounds[0].GrpEnd,   SizeOf(GrpBounds[0].GrpEnd[0])  *regNumBrackets, 0);
   FillChar(GrpSubCalled[0], SizeOf(GrpSubCalled[0])*regNumBrackets, 0);
 end;
 
@@ -6429,7 +6428,7 @@ begin
       FindSubstGroupIndex(p, n, GroupFound);
     if GroupFound then
     begin
-      if n >= 0 then
+      if (n >= 0) and (GrpBounds[0].GrpStart[n] <> nil) then
         Inc(ResultLen, GrpBounds[0].GrpEnd[n] - GrpBounds[0].GrpStart[n]);
     end
     else
@@ -6489,7 +6488,10 @@ begin
       if n >= 0 then
       begin
         p0 := GrpBounds[0].GrpStart[n];
-        p1 := GrpBounds[0].GrpEnd[n];
+        if p0 = nil then
+          p1 := nil
+        else
+          p1 := GrpBounds[0].GrpEnd[n];
       end
       else
         p1 := p0;

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -558,7 +558,7 @@ type
     function MatchAtOnePos(APos: PRegExprChar): boolean; {$IFDEF InlineFuncs}inline;{$ENDIF}
 
     // Exec for stored InputString
-    function ExecPrim(AOffset: integer; ATryOnce, ASlowChecks, ABackward: boolean; ATryMatchOnlyStartingBefore: Integer): boolean;
+    function ExecPrim(AOffset: integer; ASlowChecks, ABackward: boolean; ATryMatchOnlyStartingBefore: Integer): boolean;
 
     function GetSubExprCount: integer;
     function GetMatchPos(Idx: integer): PtrInt;
@@ -5963,7 +5963,7 @@ end; { of function TRegExpr.MatchPrim
 function TRegExpr.Exec(const AInputString: RegExprString): boolean;
 begin
   InputString := AInputString;
-  Result := ExecPrim(1, False, False, False, 0);
+  Result := ExecPrim(1, False, False, 0);
 end; { of function TRegExpr.Exec
   -------------------------------------------------------------- }
 
@@ -5973,32 +5973,35 @@ var
   SlowChecks: boolean;
 begin
   SlowChecks := fInputEnd - fInputStart < fSlowChecksSizeMax;
-  Result := ExecPrim(1, False, SlowChecks, False, 0);
+  Result := ExecPrim(1, SlowChecks, False, 0);
 end; { of function TRegExpr.Exec
   -------------------------------------------------------------- }
 
 function TRegExpr.Exec(AOffset: integer): boolean;
 begin
-  Result := ExecPrim(AOffset, False, False, False, 0);
+  Result := ExecPrim(AOffset, False, False, 0);
 end; { of function TRegExpr.Exec
   -------------------------------------------------------------- }
 {$ENDIF}
 
 function TRegExpr.ExecPos(AOffset: integer {$IFDEF DefParam} = 1{$ENDIF}): boolean;
 begin
-  Result := ExecPrim(AOffset, False, False, False, 0);
+  Result := ExecPrim(AOffset, False, False, 0);
 end; { of function TRegExpr.ExecPos
   -------------------------------------------------------------- }
 
 {$IFDEF OverMeth}
 function TRegExpr.ExecPos(AOffset: integer; ATryOnce, ABackward: boolean): boolean;
 begin
-  Result := ExecPrim(AOffset, ATryOnce, False, ABackward, 0);
+  if ATryOnce then
+    Result := ExecPrim(AOffset, False, ABackward, AOffset + 1)
+  else
+    Result := ExecPrim(AOffset, False, ABackward, 0);
 end;
 
 function TRegExpr.ExecPos(AOffset, ATryMatchOnlyStartingBefore: integer): boolean;
 begin
-  Result := ExecPrim(AOffset, False, False, False, ATryMatchOnlyStartingBefore);
+  Result := ExecPrim(AOffset, False, False, ATryMatchOnlyStartingBefore);
 end;
 {$ENDIF}
 
@@ -6053,8 +6056,8 @@ begin
   GrpCount := 0;
 end;
 
-function TRegExpr.ExecPrim(AOffset: integer; ATryOnce, ASlowChecks,
-  ABackward: boolean; ATryMatchOnlyStartingBefore: Integer): boolean;
+function TRegExpr.ExecPrim(AOffset: integer; ASlowChecks, ABackward: boolean;
+  ATryMatchOnlyStartingBefore: Integer): boolean;
 var
   Ptr: PRegExprChar;
 begin
@@ -6104,7 +6107,7 @@ begin
         exit;
 
   // ATryOnce or anchored match (it needs to be tried only once).
-  if ATryOnce or (regAnchored in [raBOL, raOnlyOnce, raContinue]) then
+  if (ATryMatchOnlyStartingBefore = AOffset + 1) or (regAnchored in [raBOL, raOnlyOnce, raContinue]) then
   begin
     case regAnchored of
       raBOL: if AOffset > 1 then Exit; // can't match the BOL
@@ -6178,7 +6181,7 @@ begin
   if PtrBegin = PtrEnd then
     Inc(Offset);
 
-  Result := ExecPrim(Offset, False, False, ABackward, 0);
+  Result := ExecPrim(Offset, False, ABackward, 0);
 end; { of function TRegExpr.ExecNext
   -------------------------------------------------------------- }
 
@@ -7622,7 +7625,10 @@ end; { of procedure TRegExpr.Error
 {$IFDEF Compat} // APIs needed only for users of old FPC 3.0
 function TRegExpr.ExecPos(AOffset: integer; ATryOnce: boolean): boolean; overload;
 begin
-  Result := ExecPrim(AOffset, ATryOnce, False, False, 0);
+  if ATryOnce then
+    Result := ExecPrim(AOffset, False, False, AOffset + 1)
+  else
+    Result := ExecPrim(AOffset, False, False, 0);
 end;
 
 function TRegExpr.OldInvertCase(const Ch: REChar): REChar;

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -518,7 +518,8 @@ type
     // ###0.90
 
     // regular expression, i.e. main body or parenthesized thing
-    function ParseReg(InBrackets: boolean; var FlagParse: integer; EndOnBracket: boolean = False; EnderOP: TReOp = TReOp(0)): PRegExprChar;
+    function ParseReg(InBrackets: boolean; var FlagParse: integer): PRegExprChar;
+    function DoParseReg(InBrackets: boolean; var FlagParse: integer; EndOnBracket: boolean; EnderOP: TReOp): PRegExprChar;
 
     // one alternative of an | operator
     function ParseBranch(var FlagParse: integer): PRegExprChar;
@@ -3161,7 +3162,12 @@ begin
 end; { of function TRegExpr.CompileRegExpr
   -------------------------------------------------------------- }
 
-function TRegExpr.ParseReg(InBrackets: boolean; var FlagParse: integer;
+function TRegExpr.ParseReg(InBrackets: boolean; var FlagParse: integer): PRegExprChar;
+begin
+  Result := DoParseReg(InBrackets, FlagParse, False, TReOp(0));
+end;
+
+function TRegExpr.DoParseReg(InBrackets: boolean; var FlagParse: integer;
   EndOnBracket: boolean; EnderOP: TReOp): PRegExprChar;
 // regular expression, i.e. main body or parenthesized thing
 // Caller must absorb opening parenthesis.
@@ -4315,7 +4321,7 @@ begin
                 gkLookaheadNeg: ret := EmitNode(OP_LOOKAHEAD_NEG);
               end;
 
-              Result := ParseReg(False, FlagTemp, True, OP_LOOKAHEAD_END);
+              Result := DoParseReg(False, FlagTemp, True, OP_LOOKAHEAD_END);
               if Result = nil then
                 Exit;
 
@@ -4337,7 +4343,7 @@ begin
                 Inc(regCodeSize, ReOpLookBehindOptionsSz);
 
               RegGrpCountBefore := GrpCount;
-              Result := ParseReg(False, FlagTemp, True, OP_LOOKBEHIND_END);
+              Result := DoParseReg(False, FlagTemp, True, OP_LOOKBEHIND_END);
               if Result = nil then
                 Exit;
 

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -7662,6 +7662,15 @@ begin
           Inc(s, REBracesArgSz * 2);
         end;
 
+      OP_BSUBEXP, OP_BSUBEXPCI:
+        begin
+          Inc(s, 1);
+          if flfForceToStopAt in Flags then
+            NotFixedLen := True
+          else
+            Exit;
+        end;
+
       else
         if flfForceToStopAt in Flags then
           NotFixedLen := True

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -558,7 +558,7 @@ type
     function MatchAtOnePos(APos: PRegExprChar): boolean; {$IFDEF InlineFuncs}inline;{$ENDIF}
 
     // Exec for stored InputString
-    function ExecPrim(AOffset: integer; ATryOnce, ASlowChecks, ABackward: boolean): boolean;
+    function ExecPrim(AOffset: integer; ATryOnce, ASlowChecks, ABackward: boolean; ATryMatchOnlyStartingBefore: Integer): boolean;
 
     function GetSubExprCount: integer;
     function GetMatchPos(Idx: integer): PtrInt;
@@ -614,7 +614,12 @@ type
     // (AOffset=1 - first char of InputString)
     function ExecPos(AOffset: integer {$IFDEF DefParam} = 1{$ENDIF}): boolean;
     {$IFDEF OverMeth} overload;
+    // find match for InputString at AOffset.
+    // if ATryOnce=True then only match exactly at AOffset (like anchor \G)
+    // if ATryMatchOnlyStartingBefore then only when the match can start before
+    // that position: Result := MatchPos[0] < ATryMatchOnlyStartingBefore;
     function ExecPos(AOffset: integer; ATryOnce, ABackward: boolean): boolean; overload;
+    function ExecPos(AOffset, ATryMatchOnlyStartingBefore: integer): boolean; overload;
     {$ENDIF}
 
     // Returns ATemplate with '$&' or '$0' replaced by whole r.e.
@@ -5958,7 +5963,7 @@ end; { of function TRegExpr.MatchPrim
 function TRegExpr.Exec(const AInputString: RegExprString): boolean;
 begin
   InputString := AInputString;
-  Result := ExecPrim(1, False, False, False);
+  Result := ExecPrim(1, False, False, False, 0);
 end; { of function TRegExpr.Exec
   -------------------------------------------------------------- }
 
@@ -5968,27 +5973,32 @@ var
   SlowChecks: boolean;
 begin
   SlowChecks := fInputEnd - fInputStart < fSlowChecksSizeMax;
-  Result := ExecPrim(1, False, SlowChecks, False);
+  Result := ExecPrim(1, False, SlowChecks, False, 0);
 end; { of function TRegExpr.Exec
   -------------------------------------------------------------- }
 
 function TRegExpr.Exec(AOffset: integer): boolean;
 begin
-  Result := ExecPrim(AOffset, False, False, False);
+  Result := ExecPrim(AOffset, False, False, False, 0);
 end; { of function TRegExpr.Exec
   -------------------------------------------------------------- }
 {$ENDIF}
 
 function TRegExpr.ExecPos(AOffset: integer {$IFDEF DefParam} = 1{$ENDIF}): boolean;
 begin
-  Result := ExecPrim(AOffset, False, False, False);
+  Result := ExecPrim(AOffset, False, False, False, 0);
 end; { of function TRegExpr.ExecPos
   -------------------------------------------------------------- }
 
 {$IFDEF OverMeth}
 function TRegExpr.ExecPos(AOffset: integer; ATryOnce, ABackward: boolean): boolean;
 begin
-  Result := ExecPrim(AOffset, ATryOnce, False, ABackward);
+  Result := ExecPrim(AOffset, ATryOnce, False, ABackward, 0);
+end;
+
+function TRegExpr.ExecPos(AOffset, ATryMatchOnlyStartingBefore: integer): boolean;
+begin
+  Result := ExecPrim(AOffset, False, False, False, ATryMatchOnlyStartingBefore);
 end;
 {$ENDIF}
 
@@ -6043,8 +6053,8 @@ begin
   GrpCount := 0;
 end;
 
-function TRegExpr.ExecPrim(AOffset: integer;
-  ATryOnce, ASlowChecks, ABackward: boolean): boolean;
+function TRegExpr.ExecPrim(AOffset: integer; ATryOnce, ASlowChecks,
+  ABackward: boolean; ATryMatchOnlyStartingBefore: Integer): boolean;
 var
   Ptr: PRegExprChar;
 begin
@@ -6077,6 +6087,8 @@ begin
     Error(reeOffsetMustBePositive);
     Exit;
   end;
+  if (ATryMatchOnlyStartingBefore > 0) and (AOffset >= ATryMatchOnlyStartingBefore) then
+    Exit;
 
   // Check that the start position is not longer than the line
   if (AOffset - 1) > (fInputEnd - fInputStart) then
@@ -6127,6 +6139,8 @@ begin
       Inc(Ptr);
       if Ptr > fInputEnd then
         Exit;
+      if (ATryMatchOnlyStartingBefore > 0) and (Ptr - fInputStart >= ATryMatchOnlyStartingBefore - 1) then
+        Exit;
     end;
 
     {$IFDEF UseFirstCharSet}
@@ -6164,7 +6178,7 @@ begin
   if PtrBegin = PtrEnd then
     Inc(Offset);
 
-  Result := ExecPrim(Offset, False, False, ABackward);
+  Result := ExecPrim(Offset, False, False, ABackward, 0);
 end; { of function TRegExpr.ExecNext
   -------------------------------------------------------------- }
 
@@ -7608,7 +7622,7 @@ end; { of procedure TRegExpr.Error
 {$IFDEF Compat} // APIs needed only for users of old FPC 3.0
 function TRegExpr.ExecPos(AOffset: integer; ATryOnce: boolean): boolean; overload;
 begin
-  Result := ExecPrim(AOffset, ATryOnce, False, False);
+  Result := ExecPrim(AOffset, ATryOnce, False, False, 0);
 end;
 
 function TRegExpr.OldInvertCase(const Ch: REChar): REChar;

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -889,7 +889,7 @@ uses
 const
   // TRegExpr.VersionMajor/Minor return values of these constants:
   REVersionMajor = 1;
-  REVersionMinor = 166;
+  REVersionMinor = 167;
 
   OpKind_End = REChar(1);
   OpKind_MetaClass = REChar(2);

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -5905,7 +5905,8 @@ begin
           if regRecursion < RegexMaxRecursion then
           begin
             Inc(regRecursion);
-            FillChar(GrpBounds[regRecursion], SizeOf(GrpBounds[regRecursion]), 0);
+            FillChar(GrpBounds[regRecursion].GrpStart, SizeOf(GrpBounds[0].GrpStart[regRecursion])*regNumBrackets, 0);
+            FillChar(GrpBounds[regRecursion].GrpEnd,   SizeOf(GrpBounds[0].GrpEnd[regRecursion])  *regNumBrackets, 0);
             bound1 := MatchPrim(regCodeWork);
             Dec(regRecursion);
           end
@@ -5927,7 +5928,8 @@ begin
             saveSubCalled := GrpSubCalled[no];
             GrpSubCalled[no] := True;
             Inc(regRecursion);
-            FillChar(GrpBounds[regRecursion], SizeOf(GrpBounds[regRecursion]), 0);
+            FillChar(GrpBounds[regRecursion].GrpStart, SizeOf(GrpBounds[0].GrpStart[regRecursion])*regNumBrackets, 0);
+            FillChar(GrpBounds[regRecursion].GrpEnd,   SizeOf(GrpBounds[0].GrpEnd[regRecursion])  *regNumBrackets, 0);
             bound1 := MatchPrim(save);
             Dec(regRecursion);
             GrpSubCalled[no] := saveSubCalled;
@@ -6024,14 +6026,15 @@ end;
 
 procedure TRegExpr.ClearMatches;
 begin
-  FillChar(GrpBounds[0], SizeOf(GrpBounds[0]), 0);
-  FillChar(GrpSubCalled, SizeOf(GrpSubCalled), 0);
+  FillChar(GrpBounds[0].GrpStart, SizeOf(GrpBounds[0].GrpStart[0])*regNumBrackets, 0);
+  FillChar(GrpBounds[0].GrpEnd,   SizeOf(GrpBounds[0].GrpEnd[0])  *regNumBrackets, 0);
+  FillChar(GrpSubCalled[0], SizeOf(GrpSubCalled[0])*regNumBrackets, 0);
 end;
 
 procedure TRegExpr.ClearInternalExecData;
 begin
   fLastError := reeOk;
-  FillChar(GrpBacktrackingAsAtom, SizeOf(GrpBacktrackingAsAtom), 0);
+  FillChar(GrpBacktrackingAsAtom[0], SizeOf(GrpBacktrackingAsAtom[0])*regNumBrackets, 0);
   IsBacktrackingGroupAsAtom := False;
   {$IFDEF ComplexBraces}
   // no loops started
@@ -6046,7 +6049,6 @@ var
 begin
   FillChar(GrpBounds[0], SizeOf(GrpBounds[0]), 0);
   FillChar(GrpAtomic, SizeOf(GrpAtomic), 0);
-  FillChar(GrpSubCalled, SizeOf(GrpSubCalled), 0);
   FillChar(GrpOpCodes, SizeOf(GrpOpCodes), 0);
 
   for i := 0 to RegexMaxGroups - 1 do

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -5905,6 +5905,7 @@ begin
           if regRecursion < RegexMaxRecursion then
           begin
             Inc(regRecursion);
+            FillChar(GrpBounds[regRecursion], SizeOf(GrpBounds[regRecursion]), 0);
             bound1 := MatchPrim(regCodeWork);
             Dec(regRecursion);
           end
@@ -5926,6 +5927,7 @@ begin
             saveSubCalled := GrpSubCalled[no];
             GrpSubCalled[no] := True;
             Inc(regRecursion);
+            FillChar(GrpBounds[regRecursion], SizeOf(GrpBounds[regRecursion]), 0);
             bound1 := MatchPrim(save);
             Dec(regRecursion);
             GrpSubCalled[no] := saveSubCalled;
@@ -6022,7 +6024,7 @@ end;
 
 procedure TRegExpr.ClearMatches;
 begin
-  FillChar(GrpBounds, SizeOf(GrpBounds), 0);
+  FillChar(GrpBounds[0], SizeOf(GrpBounds[0]), 0);
   FillChar(GrpSubCalled, SizeOf(GrpSubCalled), 0);
 end;
 
@@ -6042,7 +6044,7 @@ procedure TRegExpr.ClearInternalIndexes;
 var
   i: integer;
 begin
-  FillChar(GrpBounds, SizeOf(GrpBounds), 0);
+  FillChar(GrpBounds[0], SizeOf(GrpBounds[0]), 0);
   FillChar(GrpAtomic, SizeOf(GrpAtomic), 0);
   FillChar(GrpSubCalled, SizeOf(GrpSubCalled), 0);
   FillChar(GrpOpCodes, SizeOf(GrpOpCodes), 0);

--- a/test/tests.pas
+++ b/test/tests.pas
@@ -74,6 +74,7 @@ type
     procedure TestAtomic;
     procedure TestBraces;
     procedure TestLoop;
+    procedure TestRecurseAndCaptures;
     procedure TestIsFixedLength;
     procedure TestMatchBefore;
     procedure TestAnchor;
@@ -1303,6 +1304,32 @@ begin
   IsMatching('atomic nested {} no greedy ',
              '(?:(?>Aa(x|y(x|y(x|y){3,4}?){3,4}?){3,4}?)|.*)B',
              'AayyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyBB',   [1,44,   -1,-1, -1,-1, -1,-1] ); // 40 y
+
+
+end;
+
+procedure TTestRegexpr.TestRecurseAndCaptures;
+begin
+  // recurse capture "B", but outer does not capture
+  IsMatching('Capture in recurse does not bleed into result',
+             '[aA](?R)?(?:X|([bB]))',
+             'aABXc',  [1,4,  -1,-1]);
+
+  IsMatching('backref does NOT see outer capture',
+             '(?:x|([abc]))(?R)?-\1*',  'aabxa-a-b-b-a-a',  [4, 5,  -1,-1]);
+  IsMatching('backref does NOT see outer capture',
+             '(?:x|([abc]))(?R)?-\1*',  'aabxa-a--b-a-a',  [1, 14,  1,1]);
+  IsMatching('backref does NOT see outer capture',
+             '(?:x|([abc]))(?R)?-\1',  'aabxa-a-b-b-a-a',  [5, 3,  5,1]);
+
+
+  IsMatching('2nd recurse does NOT see capture from earlier recurse',
+             '[aA](?R)?(?:X|([bcBC]))(?R)?\1',
+             'aABBcAXBc',  [2,3,  3,1]);
+
+  IsMatching('2nd recurse does NOT see capture from earlier recurse',
+             '[aA]((?R))?(?:X|([bcBC]))((?R))?\2',
+             'aABBcAXBc',  [2,3,  -1,-1,  3,1,  -1,-1]);
 
 
 end;

--- a/test/tests.pas
+++ b/test/tests.pas
@@ -1516,6 +1516,26 @@ procedure TTestRegexpr.TestIsFixedLength;
     end;
   end;
 
+  procedure HasFixedLookBehind(AErrorMessage: String; ARegEx: RegExprString);
+  var
+    s: RegExprString;
+  begin
+    CompileRE(ARegEx);
+    s := RE.Dump();
+    //IsTrue(AErrorMessage, pos('Len:', s) > 0);
+    IsTrue(AErrorMessage, pos('greedy', s) <= 0);
+  end;
+
+  procedure HasVarLenLookBehind(AErrorMessage: String; ARegEx: RegExprString);
+  var
+    s: RegExprString;
+  begin
+    CompileRE(ARegEx);
+    s := RE.Dump();
+    //IsTrue(AErrorMessage, pos('Len:', s) <= 0);
+    IsTrue(AErrorMessage, pos('greedy', s) > 0);
+  end;
+
 begin
   HasLength('bound', '^',      0);
   HasLength('bound', '$',      0);
@@ -1603,6 +1623,15 @@ begin
 
 
   HasLength('look behind is not (yet) fixed', '(?<=.A...)(X)',   -1);
+
+  HasVarLenLookBehind('', '()A(?<=.(?<=\1))');
+  HasVarLenLookBehind('', '()A(?<=.(?<=\4))');
+  HasVarLenLookBehind('', '()A(?<=.(?<=(?1)))');
+  HasVarLenLookBehind('', '()A(?<=.(?<=(?4)))');
+  HasVarLenLookBehind('', '()A(?<=.(?<=(?R)))');
+  HasFixedLookBehind ('', '()A(?<=.(?<=\p{Lu}))');
+  HasFixedLookBehind ('', '()A(?<=.(?<=[a-x]))');
+
 end;
 
 procedure TTestRegexpr.TestMatchBefore;

--- a/test/tests.pas
+++ b/test/tests.pas
@@ -1154,21 +1154,41 @@ begin
 end;
 
 procedure TTestRegexpr.TestBraces;
+var
+  i: Integer;
+  s: RegExprString;
 begin
-  RE.AllowLiteralBraceWithoutRange:= False;
-  TestBadRegex('No Error for bad braces', 'd{');
-  TestBadRegex('No Error for bad braces', 'd{22');
-  TestBadRegex('No Error for bad braces', 'd{}');
-  TestBadRegex('No Error for bad braces', 'd{,}');
-  TestBadRegex('No Error for bad braces', 'd{x}');
-  TestBadRegex('No Error for bad braces', 'd{1x}');
-  TestBadRegex('No Error for bad braces', 'd{1,x}');
-  TestBadRegex('No Error for bad braces', 'd{1,2{');
-  TestBadRegex('No Error for bad braces', 'd{1,2,3}');
-  RE.AllowBraceWithoutMin := False;
-  TestBadRegex('No Error for bad braces', 'd{,2}');
+  for i := 0 to 9 do begin
+    case i of
+      0: s := 'd';
+      1: s := 'd?';
+      2: s := 'd+';
+      3: s := 'd*';
+      4: s := 'd*?';
+      5: s := 'd*+';
+      6: s := '(?=.)';
+      7: s := '(?=.)?';
+      8: s := '(?=.)*';
+      9: s := '(?=.)+';
+    end;
+    RE.AllowLiteralBraceWithoutRange:= False;
+    TestBadRegex('No Error for bad braces', s+'{');
+    TestBadRegex('No Error for bad braces', s+'{22');
+    TestBadRegex('No Error for bad braces', s+'{}');
+    TestBadRegex('No Error for bad braces', s+'{,}');
+    TestBadRegex('No Error for bad braces', s+'{x}');
+    TestBadRegex('No Error for bad braces', s+'{1x}');
+    TestBadRegex('No Error for bad braces', s+'{1,x}');
+    TestBadRegex('No Error for bad braces', s+'{1,2{');
+    TestBadRegex('No Error for bad braces', s+'{1,2,3}');
+    RE.AllowBraceWithoutMin := False;
+    TestBadRegex('No Error for bad braces', s+'{,2}');
+  end;
+
+
   RE.AllowBraceWithoutMin := True;
   IsMatching('{,5} ',  'a{,5}',  'bcaaaaaaaaXa{2,5}Xa{2,}Xa{}Xa{,}Xa{,5}Xa{x}_',  [1,0]);
+
 
   RE.AllowLiteralBraceWithoutRange := True;
   RE.AllowBraceWithoutMin := True;
@@ -1176,20 +1196,41 @@ begin
   IsMatching('{,5} ',  'a{,5}',  'bcaaaaaaaaXa{2,5}Xa{2,}Xa{}Xa{,}Xa{,5}Xa{x}_',  [1,0]);
   IsMatching('{,5} ',  '.{,5}',  'bcaaaaaaaaXa{2,5}Xa{2,}Xa{}Xa{,}Xa{,5}Xa{x}_',  [1,5]);
   IsMatching('{2,} ',  'a{2,}',  'bcaaaaaaaaXa{2,5}Xa{2,}Xa{}Xa{,}Xa{,5}Xa{x}_',  [3,8]);
-  IsMatching('{}',     'a{}',    'bcaaaaaaaaXa{2,5}Xa{2,}Xa{}Xa{,}Xa{,5}Xa{x}_',  [25,3]);
-  IsMatching('{,} ',   'a{,}',   'bcaaaaaaaaXa{2,5}Xa{2,}Xa{}Xa{,}Xa{,5}Xa{x}_',  [29,4]);
-  IsMatching('{x} ',   'a{x}',   'bcaaaaaaaaXa{2,5}Xa{2,}Xa{}Xa{,}Xa{,5}Xa{x}_',  [40,4]);
+
+  for i := 0 to 6 do begin
+    case i of
+      0: s := 'a';
+      1: s := 'a?';
+      2: s := '.';
+      3: s := 'a(?=.)';
+      4: s := 'a(?=.)?';
+      5: s := 'a(?=.)+';
+      6: s := 'a(?=.)*';
+    end;
+    IsMatching('{}',     s+'{}',    'bcaaaaaaaaXa{2,5}Xa{2,}Xa{}Xa{,}Xa{,5}Xa{x}_',  [25,3]);
+    IsMatching('{,} ',   s+'{,}',   'bcaaaaaaaaXa{2,5}Xa{2,}Xa{}Xa{,}Xa{,5}Xa{x}_',  [29,4]);
+    IsMatching('{x} ',   s+'{x}',   'bcaaaaaaaaXa{2,5}Xa{2,}Xa{}Xa{,}Xa{,5}Xa{x}_',  [40,4]);
+  end;
 
   IsMatching('{2,5}?', 'a{2,5}?', 'bcaaaaaaaaXa{2,5}Xa{2,}Xa{}Xa{,}Xa{,5}Xa{x}_',  [3,2]);
   IsMatching('{,5}?',  'a{,5}?',  'bcaaaaaaaaXa{2,5}Xa{2,}Xa{}Xa{,}Xa{,5}Xa{x}_',  [1,0]);
   IsMatching('{,5}?',  '.{,5}?',  'bcaaaaaaaaXa{2,5}Xa{2,}Xa{}Xa{,}Xa{,5}Xa{x}_',  [1,0]);
   IsMatching('{2,}?',  'a{2,}?',  'bcaaaaaaaaXa{2,5}Xa{2,}Xa{}Xa{,}Xa{,5}Xa{x}_',  [3,2]);
-  IsMatching('{}?',    'a{}?',    'bcaaaaaaaaXa{2,5}Xa{2,}Xa{}Xa{,}Xa{,5}Xa{x}_',  [12,2]);
-  IsMatching('{,}?',   'a{,}?',   'bcaaaaaaaaXa{2,5}Xa{2,}Xa{}Xa{,}Xa{,5}Xa{x}_',  [29,4]);
-  IsMatching('{x}?',   'a{x}?',   'bcaaaaaaaaXa{2,5}Xa{2,}Xa{}Xa{,}Xa{,5}Xa{x}_',  [40,4]);
 
-  TestBadRegex('No Error for bad braces', 'd{2,1}');
-
+  for i := 0 to 6 do begin
+    case i of
+      0: s := 'a';
+      1: s := 'a?';
+      2: s := '.';
+      3: s := 'a(?=.)';
+      4: s := 'a(?=.)?';
+      5: s := 'a(?=.)+';
+      6: s := 'a(?=.)*';
+    end;
+    IsMatching('{}?',    'a{}?',    'bcaaaaaaaaXa{2,5}Xa{2,}Xa{}Xa{,}Xa{,5}Xa{x}_',  [12,2]);
+    IsMatching('{,}?',   'a{,}?',   'bcaaaaaaaaXa{2,5}Xa{2,}Xa{}Xa{,}Xa{,5}Xa{x}_',  [29,4]);
+    IsMatching('{x}?',   'a{x}?',   'bcaaaaaaaaXa{2,5}Xa{2,}Xa{}Xa{,}Xa{,5}Xa{x}_',  [40,4]);
+  end;
 
   RE.AllowBraceWithoutMin := False;
   IsMatching('{2,5} ', 'a{2,5}', 'bcaaaaaaaaXa{2,5}Xa{2,}Xa{}Xa{,}Xa{,5}Xa{x}_',  [3,5]);
@@ -1208,6 +1249,8 @@ begin
   IsMatching('{,}?',   'a{,}?',   'bcaaaaaaaaXa{2,5}Xa{2,}Xa{}Xa{,}Xa{,5}Xa{x}_',  [29,4]);
   IsMatching('{x} ',   'a{x}?',   'bcaaaaaaaaXa{2,5}Xa{2,}Xa{}Xa{,}Xa{,5}Xa{x}_',  [40,4]);
 
+
+  TestBadRegex('No Error for bad braces', 'd{2,1}');
   TestBadRegex('No Error for bad braces', 'd{2,1}');
 end;
 


### PR DESCRIPTION
Fix #324 comment 1. Subsequent (side-by-side) recursive calls did see data captured in previous calls.
Improve speed.

Include existing PR #323  and #322 

@Alexey-T 

All tests work for the old and new recursion behaviour. Except
```
IsMatching('2nd recurse does NOT see capture from earlier recurse',
             '[aA](?R)?(?:X|([bcBC]))(?R)?\1',
             'aABBcAXBc',  [2,3,  3,1]);

  IsMatching('2nd recurse does NOT see capture from earlier recurse',
             '[aA]((?R))?(?:X|([bcBC]))((?R))?\2',
             'aABBcAXBc',  [2,3,  -1,-1,  3,1,  -1,-1]);
```

Which are specially crafted to exploit the issue in the old behaviour