### PR TITLE
Review / Variable amount of Groups

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -6,6 +6,11 @@
                                      (-) - bugfix
                                      (^) - improvement
 
+ v. 1.169 2023.09.16
+ -=- (^) Removed limit to "Max number of groups" (RegexMaxGroups).
+ -=- (-) Fixed recursive sub calls. Sub call could return to early.
+  By Martin Friebe.
+
  v. 1.167 2023.09.13
  -=- (+) Added Exec(AOffset, AMatchMustStartBefore: integer)
   Limit the search for the first matched position to AMatchMustStartBefore

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -4315,6 +4315,10 @@ begin
                       end;
                     '0'..'9':
                       begin
+                        if GrpIndex > (High(GrpIndex)-10) div 10 then begin
+                          Error(reeBadRecursion);
+                          exit;
+                        end;
                         GrpIndex := GrpIndex * 10 + Ord(regParse^) - Ord('0');
                         Inc(regParse);
                       end
@@ -4634,6 +4638,10 @@ begin
                     GrpIndex := 0;
                     inc(regParse);
                     while (regParse^ >= '0') and (regParse^ <= '9') do begin
+                      if GrpIndex > (High(GrpIndex)-10) div 10 then begin
+                        Error(reeBadReference);
+                        exit;
+                      end;
                       GrpIndex := GrpIndex * 10 + (Ord(regParse^) - Ord('0'));
                       inc(regParse);
                     end;

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -123,7 +123,7 @@ uses
     Character,
     {$ENDIF}
   {$ENDIF}
-  Classes, Math; // TStrings in Split method
+  Classes; // TStrings in Split method
 
 type
   {$IFNDEF FPC}
@@ -3067,7 +3067,7 @@ function TRegExpr.CompileRegExpr(ARegExp: PRegExprChar): boolean;
 var
   scan, scanTemp, longest, longestTemp: PRegExprChar;
   Len, LenTemp: integer;
-  FlagTemp, i: integer;
+  FlagTemp: integer;
 begin
   Result := False;
   FlagTemp := 0;
@@ -3975,7 +3975,7 @@ var
   DashForRange: Boolean;
   GrpKind: TREGroupKind;
   GrpName: RegExprString;
-  GrpIndex, ALen, RegGrpCountBefore, i: integer;
+  GrpIndex, ALen, RegGrpCountBefore: integer;
   NextCh: REChar;
   op: TREOp;
   SavedModifiers: TRegExprModifiers;

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -903,7 +903,7 @@ uses
 const
   // TRegExpr.VersionMajor/Minor return values of these constants:
   REVersionMajor = 1;
-  REVersionMinor = 167;
+  REVersionMinor = 169;
 
   OpKind_End = REChar(1);
   OpKind_MetaClass = REChar(2);

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -206,10 +206,8 @@ const
   RegExprReplaceLineBreak: RegExprString = sLineBreak;
 
 const
-  // Max number of groups.
-  // Be carefull - don't use values which overflow OP_CLOSE* opcode
-  // (in this case you'll get compiler error).
-  // Big value causes slower work and more stack required.
+  // Increment/keep-capacity for the size of arrays holding 'Group' related data
+  // e.g., GrpBounds, GrpIndexes, GrpOpCodes and GrpNames
   RegexGroupCountIncrement = 50;
 
   // Max possible amount of groups.

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -3510,7 +3510,7 @@ var
   function ParseBraceMinMax(var BMin, BMax: TREBracesArg): boolean;
   begin
     Result := DoParseBraceMinMax(BMin, BMax);
-    if BMin > BMax then
+    if Result and (BMin > BMax) then
     begin
       Error(reeBracesMinParamGreaterMax);
       Exit;
@@ -7583,6 +7583,7 @@ var
   NotFixedLen: Boolean;
 begin
   Result := False;
+  NotFixedLen := False;
   ALen := 0;
   s := prog;
 

--- a/test/tests.pas
+++ b/test/tests.pas
@@ -1359,6 +1359,16 @@ begin
              '(?i)(.)(.)(.)(.)(.)(.)(.)(.)(.)(.)(.)(.)\g11',
              'x123456789ABCbD',   [2,13,   2,1, 3,1, 4,1, 5,1, 6,1, 7,1, 8,1, 9,1, 10,1,  11,1,  12,1,  13,1] );
 
+
+  IsMatching('Valid capture idx', '(.)(.)\2',  'aABBC',  [2,3,  2,1, 3,1]);
+  TestBadRegex('Invalid capture idx', '(.)(.)\3');
+
+  IsMatching('Valid capture idx \g', '(.)(.)\g2',  'aABBC',  [2,3,  2,1, 3,1]);
+  TestBadRegex('Invalid capture idx \c', '(.)(.)\g3');
+
+  IsMatching('Valid call idx', '(.)(.)(?2)',  'aABBC',  [1,3,  1,1, 2,1]);
+  TestBadRegex('Invalid call idx', '(.)(.)(?3)');
+
 end;
 
 procedure TTestRegexpr.TestNamedGroups;
@@ -1625,9 +1635,9 @@ begin
   HasLength('look behind is not (yet) fixed', '(?<=.A...)(X)',   -1);
 
   HasVarLenLookBehind('', '()A(?<=.(?<=\1))');
-  HasVarLenLookBehind('', '()A(?<=.(?<=\4))');
+  HasVarLenLookBehind('', '()()()()A(?<=.(?<=\4))');
   HasVarLenLookBehind('', '()A(?<=.(?<=(?1)))');
-  HasVarLenLookBehind('', '()A(?<=.(?<=(?4)))');
+  HasVarLenLookBehind('', '()()()()A(?<=.(?<=(?4)))');
   HasVarLenLookBehind('', '()A(?<=.(?<=(?R)))');
   HasFixedLookBehind ('', '()A(?<=.(?<=\p{Lu}))');
   HasFixedLookBehind ('', '()A(?<=.(?<=[a-x]))');

--- a/test/tests.pas
+++ b/test/tests.pas
@@ -936,6 +936,9 @@ begin
 
   RE.AllowUnsafeLookBehind := False;
   TestBadRegex('No Error for var-len look behind with capture', '.(?<=(.+))', 153);
+
+  TestBadRegex('value for reference to big', '()\9999999999999999999999999999999999999999999999999999()');
+  TestBadRegex('value for reference to big', '()\g9999999999999999999999999999999999999999999999999999()');
 end;
 
 procedure TTestRegexpr.TestModifiers;

--- a/test/tests.pas
+++ b/test/tests.pas
@@ -1443,6 +1443,9 @@ begin
       IsNotMatching('2 Named ref backwards',
                  '^' + n + n2 + r2 + r,      'axbxaxbx__' );
 
+      // forward ref
+      IsMatching('Named forward ref',
+                 '(?:(?:' + r + '|x)' + n + ')+_',      'abxababab_ab',  [3,8,  8,2]);
     end;
 
 
@@ -1473,6 +1476,9 @@ begin
       IsNotMatching('2 Named ref backwards',
                  '^' + n + n2 + c2 + c,      'axbxaxbx__' );
 
+      // forward call
+      IsMatching('Named forward call',
+                 '(?:(?:' + c + '|x)' + n + ')+_',      'abxabABab_ab',  [3,8,  8,2]);
     end;
   end;
 

--- a/test/tests.pas
+++ b/test/tests.pas
@@ -75,6 +75,7 @@ type
     procedure TestBraces;
     procedure TestLoop;
     procedure TestReferences;
+    procedure TestSubCall;
     procedure TestNamedGroups;
     procedure TestRecurseAndCaptures;
     procedure TestIsFixedLength;
@@ -1368,6 +1369,25 @@ begin
 
   IsMatching('Valid call idx', '(.)(.)(?2)',  'aABBC',  [1,3,  1,1, 2,1]);
   TestBadRegex('Invalid call idx', '(.)(.)(?3)');
+
+end;
+
+procedure TTestRegexpr.TestSubCall;
+begin
+  IsMatching('simple call', '(1)_(?1)',  '1_1',  [1,3,  1,1]);
+  IsNotMatching('simple call', '(1)_(?1)',  '1_2'  );
+
+  IsMatching('recurse call', '(1(?1)?_)',  'x11__',  [2,4,  2,4]);
+  IsMatching('recurse call', '(1(?1)?_)',  'x11_1',  [3,2,  3,2]);
+  IsMatching('recurse call', '(1(?1)?_)',  'x1__',   [2,2,  2,2]);
+  IsMatching('recurse call', '(1(?1)?_)',  'x111__', [3,4,  3,4]);
+
+  IsMatching('deep recurse call', '(1(?1)?_)',  'x1111____',   [2,8,  2,8]);
+
+  IsMatching('side by side recurse call', '(1((?1)?)_((?1)?)2)',  'x1111_2_1_22_1_222_',   [3,15,  3,15, 4,9, 14,3]);
+
+  IsMatching('nested call to outer', '(1(2(3(?1)?))A)_((?3))',  '123A_3123',  [1,6,  1,4, 2,2, 3,1, 6,1]);
+  IsMatching('nested call to outer', '(1(2(3(?1)?))A)_((?3))',  '123A_3123A',  [1,10,  1,4, 2,2, 3,1, 6,5]);
 
 end;
 


### PR DESCRIPTION
This
- fixes #327 
- allows (P=name) to look forward (like \1 can refer forward)
- Allows "unlimited" groups (well the list must fit into memory) :)
- removes some more FillChar

A count of groups is taken during the first pass. Then all arrays are set to their required length.

Only exception is the name array. As it needs to be populated during the first pass.
It only is grown, if an actual named-capture is found, and a name needs to be stored. 


@Alexey-T 