### PR TITLE
Allow ()* / fix Dump() / Limit Stack

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -6,6 +6,10 @@
                                      (-) - bugfix
                                      (^) - improvement
 
+ v. 1.173 2023.11.11
+ -=- (+) Allow loops (*/+/{}) on potentially zero-len patterns
+ -=- (-) Fixed uninitialized Result in Dump()
+
  v. 1.169 2023.09.16
  -=- (^) Removed limit to "Max number of groups" (RegexMaxGroups).
  -=- (-) Fixed recursive sub calls. Sub call could return to early.

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -914,7 +914,7 @@ uses
 const
   // TRegExpr.VersionMajor/Minor return values of these constants:
   REVersionMajor = 1;
-  REVersionMinor = 171;
+  REVersionMinor = 173;
 
   OpKind_End = REChar(1);
   OpKind_MetaClass = REChar(2);

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -7413,12 +7413,12 @@ var
   iByte: Byte;
   ch, ch2: REChar;
 begin
+  Result := '';
   if not IsProgrammOk then
     Exit;
 
   CurIndent := 0;
   op := OP_EXACTLY;
-  Result := '';
   s := regCodeWork;
   while op <> OP_EEND do
   begin // While that wasn't END last time...

--- a/test/tests.pas
+++ b/test/tests.pas
@@ -74,6 +74,7 @@ type
     procedure TestAtomic;
     procedure TestBraces;
     procedure TestLoop;
+    procedure TestEmptyLoop;
     procedure TestReferences;
     procedure TestSubCall;
     procedure TestNamedGroups;
@@ -929,10 +930,16 @@ end;
 
 procedure TTestRegexpr.TestBads;
 begin
-  TestBadRegex('Error for matching zero width {}', '(a{0,2})*', 115);
-//  TestBadRegex('Error for optional lookaround', '(?=a)?', 115);
-  TestBadRegex('Error for empty group (only look ahead)', '((?=a))+', 115);
-  TestBadRegex('Error for empty group (only look ahead)', '((?=a))*', 115);
+  TestBadRegex('Error for invalid loop', '*');
+  TestBadRegex('Error for invalid loop', '^*');
+  TestBadRegex('Error for invalid loop', '\b*');
+  TestBadRegex('Error for invalid loop', '+');
+  TestBadRegex('Error for invalid loop', '^+');
+  TestBadRegex('Error for invalid loop', '\b+');
+  TestBadRegex('Error for invalid loop', '.?*');
+  TestBadRegex('Error for invalid loop', '.**');
+  TestBadRegex('Error for invalid loop', '.+*');
+  TestBadRegex('Error for invalid loop', '.++?');
 
   RE.AllowUnsafeLookBehind := False;
   TestBadRegex('No Error for var-len look behind with capture', '.(?<=(.+))', 153);
@@ -1353,6 +1360,137 @@ begin
   IsMatching('atomic nested {} no greedy ',
              '(?:(?>Aa(x|y(x|y(x|y){3,4}?){3,4}?){3,4}?)|.*)B',
              'AayyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyBB',   [1,44,   -1,-1, -1,-1, -1,-1] ); // 40 y
+
+
+end;
+
+procedure TTestRegexpr.TestEmptyLoop;
+var
+  WithAtomic, LoopIdx, PtnIdx, ExpGrpPos1, ExpGrpLen1: Integer;
+  LoopTxt, PtnText: RegExprString;
+  s: String;
+  MatchZeroTimes, ForceMatchZeroTimes: Boolean;
+begin
+  for LoopIdx := 0 to 18 do begin
+    case LoopIdx of
+       0: LoopTxt := '';
+       1: LoopTxt := '?';
+       2: LoopTxt := '??';
+       3: LoopTxt := '+';
+       4: LoopTxt := '+?';
+       5: LoopTxt := '++';
+       6: LoopTxt := '*';
+       7: LoopTxt := '*?';
+       8: LoopTxt := '*+';
+       9: LoopTxt := '{0}';
+      10: LoopTxt := '{1}';
+      11: LoopTxt := '{5}';
+      12: LoopTxt := '{0,5}';
+      13: LoopTxt := '{1,5}';
+      14: LoopTxt := '{0}?';
+      15: LoopTxt := '{1}?';
+      16: LoopTxt := '{5}?';
+      17: LoopTxt := '{0,5}?';
+      18: LoopTxt := '{1,5}?';
+      //19: LoopTxt := '{0}+';
+      //20: LoopTxt := '{1}+';
+      //21: LoopTxt := '{5}+';
+      //22: LoopTxt := '{0,5}+';
+      //23: LoopTxt := '{1,5}+';
+    end;
+
+    for PtnIdx := 0 to 18 do
+    for WithAtomic := 0 to 2 do begin
+      case PtnIdx of
+         0: PtnText := '()';
+         1: PtnText := '(xx|)';
+         2: PtnText := '(|xx)';
+         3: PtnText := '(xx|(?:xx)?)';
+         4: PtnText := '(xx|(?:))';
+         5: PtnText := '(xx|(?:)*)'; // nested
+         6: PtnText := '(xx|(?:)*?)'; // nested
+         7: PtnText := '(xx|(?:)*+)'; // nested
+         8: PtnText := '(xx|(?:)+)'; // nested
+         9: PtnText := '(xx|(?:)+?)'; // nested
+        10: PtnText := '(xx|(?:)++)'; // nested
+        11: PtnText := '((?:(?:)+)*|(?:(?:)*)+)'; // nested
+        12: PtnText := '((?=))';
+        13: PtnText := '((?!X))';
+        14: PtnText := '((?=(?:)*))'; // nested in look-around
+        15: PtnText := '((?:(?:(?:)*){10,11}){20,21})';
+        16: PtnText := '((?>(?:)+)*|(?:(?:)*)+)'; // nested inner atom
+        17: PtnText := '((?:(?>)+)*|(?:(?>)*)+)'; // nested inner atom
+        18: PtnText := '(\b)';
+      end;
+       // (?> atomic
+      case WithAtomic of
+        0: ;
+        1: begin
+          Insert('(?>', PtnText, 2);
+          PtnText := PtnText + ')';
+        end;
+        2: PtnText := '(?>' + PtnText + ')';
+      end;
+
+      MatchZeroTimes := LoopIdx in [2,7,9,14,17,19];
+      ForceMatchZeroTimes := LoopIdx in [9,14,19];
+
+      ExpGrpPos1 := 1;
+      ExpGrpLen1 := 0;
+      if MatchZeroTimes then begin
+        ExpGrpPos1 := -1;
+        ExpGrpLen1 := -1;
+      end;
+
+      s := LoopTxt + ' / ' + PtnText;
+      IsMatching('Empty group '+s,                PtnText+LoopTxt,      'a',   [1,0,  ExpGrpPos1,ExpGrpLen1]);
+      if PtnIdx < 18 then
+        IsMatching('Empty group in empty text '+s,  PtnText+LoopTxt,      '',    [1,0,  ExpGrpPos1,ExpGrpLen1]);
+      IsMatching('Empty group before text '+s,    PtnText+LoopTxt+'a',  'a',   [1,1,  ExpGrpPos1,ExpGrpLen1]);
+
+      if ForceMatchZeroTimes then
+        IsNotMatching('Empty group backref '+s,   PtnText+LoopTxt+'\1', 'a')
+      else
+        IsMatching('Empty group backref '+s,          PtnText+LoopTxt+'\1', 'a',   [1,0,  1,0]);
+
+      if ForceMatchZeroTimes or (PtnIdx = 18) then
+        IsNotMatching('Empty group backref in empty'+s,  PtnText+LoopTxt+'\1', '')
+      else
+        IsMatching('Empty group backref in empty'+s,  PtnText+LoopTxt+'\1', '',    [1,0,  1,0]);
+
+
+
+      if ExpGrpPos1 > 0 then ExpGrpPos1 := 2;
+      IsMatching('Empty group after text '+s,     'a'+PtnText+LoopTxt,     'a',   [1,1,  ExpGrpPos1,ExpGrpLen1]);
+
+      if PtnIdx < 18 then begin
+        IsMatching('Empty group mid   text '+s,     'a'+PtnText+LoopTxt,     'aa',  [1,1,  ExpGrpPos1,ExpGrpLen1]);
+        IsMatching('Empty group mid   text '+s,     'a'+PtnText+LoopTxt+'a', 'aa',  [1,2,  ExpGrpPos1,ExpGrpLen1]);
+
+        if ForceMatchZeroTimes then begin
+          IsNotMatching('Empty group mid + backref at end '+s,  'a'+PtnText+LoopTxt+'a\1', 'aa');
+        end
+        else begin
+          IsMatching('Empty group mid + backref at end '+s,  'a'+PtnText+LoopTxt+'a\1', 'aa',  [1,2,  2,0]);
+          IsMatching('Empty group mid + backref at end '+s,  'a'+PtnText+LoopTxt+'a(\1)', 'aa',  [1,2,  2,0,  3,0]);
+        end;
+      end;
+
+    end;
+  end;
+
+  // The backref in the loop changes each iteration. So even if the match is empty, it must be executed the correct amount of times
+  IsMatching('Empty group match-count',  '((?=.*(?:\2|a)(.))|$){1,4}', '1234567890abcdefghi',   [1,0,  1,0,  15,1]);
+  IsMatching('Empty group match-count',  '((?=.*(?:\2|a)(.))|$){1,5}', '1234567890abcdefghi',   [1,0,  1,0,  16,1]);
+
+  IsMatching('Empty group match-count',  '((?=.*(?:\2|a)(.))|$){1,4}?', '1234567890abcdefghi',   [1,0,  1,0,  12,1]);
+  IsMatching('Empty group match-count',  '((?=.*(?:\2|a)(.))|$){1,5}?', '1234567890abcdefghi',   [1,0,  1,0,  12,1]);
+
+  IsMatching('Empty group match-count',  '((?=.*(?:\2|a)(.))|$)+', '1234567890abcdefghi',   [1,0,  1,0,  12,1]);
+  IsMatching('Empty group match-count',  '((?=.*(?:\2|a)(.))|$)+?', '1234567890abcdefghi',   [1,0,  1,0,  12,1]);
+  IsMatching('Empty group match-count',  '((?=.*(?:\2|a)(.))|$)*', '1234567890abcdefghi',   [1,0,  1,0,  12,1]);
+
+  IsMatching('Empty group match-count',  '((?=.*(?:\2|a)(.))|$)*?', '1234567890abcdefghi',   [1,0,  -1,-1,  -1,-1]);
 
 
 end;


### PR DESCRIPTION
Many (if not most) other reg ex engines allow patterns to be quantified even if they could be empty or match 0-len.

`(a|\b)*` may match zero len, but should be valid.

For `{}` they even eval the given amount of times: https://regex101.com/r/BvQROU/1 (change the "4" to "5" in the {})

----

Dump() had a potential uninitialised result.

----
```
  RegEx := TRegExpr.Create('((a){2000,4000}){2000,4000}');
//  RegEx.MaxEvalStackDepth := 100000;
  RegEx.InputString := StringOfChar('a', 100000);
  RegEx.Exec();
```
The above would cause a stack overflow.

I added a limit, to avoid the exception.

For my tests on Windows: 
- Win 10 - 64 bit fails at stack depth 45000
- Win 10 - 32 bit fails at stack depth 59000

Obviously stack size can be configured by the user, So numbers can change.

Moving more of the local vars to `TRegExprMatchPrimLocals =   record` and have them share mem, could improve the max depth.

I thought about wrapping `MatchPrim` in an outer function (which would do the inc/dec) and avoid the try/finally.
But that depends on `{$IFDEF InlineFuncs}`, and even then inlining isn't guaranteed, and if it is not inlined it is increasing stack usage.


