### PR TITLE
minimal speed improve for OP_EXACTLY_CI

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -6,6 +6,10 @@
                                      (-) - bugfix
                                      (^) - improvement
 
+ v. 1.173 2023.11.11
+ -=- (+) Allow loops (*/+/{}) on potentially zero-len patterns
+ -=- (-) Fixed uninitialized Result in Dump()
+
  v. 1.169 2023.09.16
  -=- (^) Removed limit to "Max number of groups" (RegexMaxGroups).
  -=- (-) Fixed recursive sub calls. Sub call could return to early.

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -914,7 +914,7 @@ uses
 const
   // TRegExpr.VersionMajor/Minor return values of these constants:
   REVersionMajor = 1;
-  REVersionMinor = 171;
+  REVersionMinor = 173;
 
   OpKind_End = REChar(1);
   OpKind_MetaClass = REChar(2);

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -7413,12 +7413,12 @@ var
   iByte: Byte;
   ch, ch2: REChar;
 begin
+  Result := '';
   if not IsProgrammOk then
     Exit;
 
   CurIndent := 0;
   op := OP_EXACTLY;
-  Result := '';
   s := regCodeWork;
   while op <> OP_EEND do
   begin // While that wasn't END last time...

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -3935,7 +3935,10 @@ var
     else
       ret := EmitNode(OP_EXACTLY);
     EmitInt(1);
-    EmitC(Ch);
+    if fCompModifiers.I then
+      EmitC(_UpperCase(Ch))
+    else
+      EmitC(Ch);
     FlagParse := FlagParse or FLAG_HASWIDTH or FLAG_SIMPLE;
   end;
 
@@ -4793,7 +4796,10 @@ begin
         begin
           if not fCompModifiers.X or not IsIgnoredChar(regParse^) then
           begin
-            EmitC(regParse^);
+            if fCompModifiers.I then
+              EmitC(_UpperCase(regParse^))
+            else
+              EmitC(regParse^);
             if regCode <> @regDummy then
               Inc(regExactlyLen^);
           end;
@@ -4910,7 +4916,7 @@ begin
         end;
         if Result < TheMax then
         begin // ###0.931
-          InvChar := InvertCase(opnd^); // store in register
+          InvChar := _LowerCase(opnd^); // store in register
           while (Result < TheMax) and ((opnd^ = scan^) or (InvChar = scan^)) do
           begin
             Inc(Result);
@@ -5532,7 +5538,7 @@ begin
             Exit;
           Inc(opnd, RENumberSz);
           // Inline the first character, for speed.
-          if (opnd^ <> regInput^) and (InvertCase(opnd^) <> regInput^) then
+          if (opnd^ <> regInput^) and (_LowerCase(opnd^) <> regInput^) then
             Exit;
           // ###0.929 begin
           no := Len;
@@ -5541,7 +5547,7 @@ begin
           begin
             Inc(save);
             Inc(opnd);
-            if (opnd^ <> save^) and (InvertCase(opnd^) <> save^) then
+            if (opnd^ <> save^) and (_LowerCase(opnd^) <> save^) then
               Exit;
             Dec(no);
           end;

--- a/test/tests.pas
+++ b/test/tests.pas
@@ -74,6 +74,7 @@ type
     procedure TestAtomic;
     procedure TestBraces;
     procedure TestLoop;
+    procedure TestEmptyLoop;
     procedure TestReferences;
     procedure TestSubCall;
     procedure TestNamedGroups;
@@ -929,10 +930,16 @@ end;
 
 procedure TTestRegexpr.TestBads;
 begin
-  TestBadRegex('Error for matching zero width {}', '(a{0,2})*', 115);
-//  TestBadRegex('Error for optional lookaround', '(?=a)?', 115);
-  TestBadRegex('Error for empty group (only look ahead)', '((?=a))+', 115);
-  TestBadRegex('Error for empty group (only look ahead)', '((?=a))*', 115);
+  TestBadRegex('Error for invalid loop', '*');
+  TestBadRegex('Error for invalid loop', '^*');
+  TestBadRegex('Error for invalid loop', '\b*');
+  TestBadRegex('Error for invalid loop', '+');
+  TestBadRegex('Error for invalid loop', '^+');
+  TestBadRegex('Error for invalid loop', '\b+');
+  TestBadRegex('Error for invalid loop', '.?*');
+  TestBadRegex('Error for invalid loop', '.**');
+  TestBadRegex('Error for invalid loop', '.+*');
+  TestBadRegex('Error for invalid loop', '.++?');
 
   RE.AllowUnsafeLookBehind := False;
   TestBadRegex('No Error for var-len look behind with capture', '.(?<=(.+))', 153);
@@ -1353,6 +1360,137 @@ begin
   IsMatching('atomic nested {} no greedy ',
              '(?:(?>Aa(x|y(x|y(x|y){3,4}?){3,4}?){3,4}?)|.*)B',
              'AayyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyBB',   [1,44,   -1,-1, -1,-1, -1,-1] ); // 40 y
+
+
+end;
+
+procedure TTestRegexpr.TestEmptyLoop;
+var
+  WithAtomic, LoopIdx, PtnIdx, ExpGrpPos1, ExpGrpLen1: Integer;
+  LoopTxt, PtnText: RegExprString;
+  s: String;
+  MatchZeroTimes, ForceMatchZeroTimes: Boolean;
+begin
+  for LoopIdx := 0 to 18 do begin
+    case LoopIdx of
+       0: LoopTxt := '';
+       1: LoopTxt := '?';
+       2: LoopTxt := '??';
+       3: LoopTxt := '+';
+       4: LoopTxt := '+?';
+       5: LoopTxt := '++';
+       6: LoopTxt := '*';
+       7: LoopTxt := '*?';
+       8: LoopTxt := '*+';
+       9: LoopTxt := '{0}';
+      10: LoopTxt := '{1}';
+      11: LoopTxt := '{5}';
+      12: LoopTxt := '{0,5}';
+      13: LoopTxt := '{1,5}';
+      14: LoopTxt := '{0}?';
+      15: LoopTxt := '{1}?';
+      16: LoopTxt := '{5}?';
+      17: LoopTxt := '{0,5}?';
+      18: LoopTxt := '{1,5}?';
+      //19: LoopTxt := '{0}+';
+      //20: LoopTxt := '{1}+';
+      //21: LoopTxt := '{5}+';
+      //22: LoopTxt := '{0,5}+';
+      //23: LoopTxt := '{1,5}+';
+    end;
+
+    for PtnIdx := 0 to 18 do
+    for WithAtomic := 0 to 2 do begin
+      case PtnIdx of
+         0: PtnText := '()';
+         1: PtnText := '(xx|)';
+         2: PtnText := '(|xx)';
+         3: PtnText := '(xx|(?:xx)?)';
+         4: PtnText := '(xx|(?:))';
+         5: PtnText := '(xx|(?:)*)'; // nested
+         6: PtnText := '(xx|(?:)*?)'; // nested
+         7: PtnText := '(xx|(?:)*+)'; // nested
+         8: PtnText := '(xx|(?:)+)'; // nested
+         9: PtnText := '(xx|(?:)+?)'; // nested
+        10: PtnText := '(xx|(?:)++)'; // nested
+        11: PtnText := '((?:(?:)+)*|(?:(?:)*)+)'; // nested
+        12: PtnText := '((?=))';
+        13: PtnText := '((?!X))';
+        14: PtnText := '((?=(?:)*))'; // nested in look-around
+        15: PtnText := '((?:(?:(?:)*){10,11}){20,21})';
+        16: PtnText := '((?>(?:)+)*|(?:(?:)*)+)'; // nested inner atom
+        17: PtnText := '((?:(?>)+)*|(?:(?>)*)+)'; // nested inner atom
+        18: PtnText := '(\b)';
+      end;
+       // (?> atomic
+      case WithAtomic of
+        0: ;
+        1: begin
+          Insert('(?>', PtnText, 2);
+          PtnText := PtnText + ')';
+        end;
+        2: PtnText := '(?>' + PtnText + ')';
+      end;
+
+      MatchZeroTimes := LoopIdx in [2,7,9,14,17,19];
+      ForceMatchZeroTimes := LoopIdx in [9,14,19];
+
+      ExpGrpPos1 := 1;
+      ExpGrpLen1 := 0;
+      if MatchZeroTimes then begin
+        ExpGrpPos1 := -1;
+        ExpGrpLen1 := -1;
+      end;
+
+      s := LoopTxt + ' / ' + PtnText;
+      IsMatching('Empty group '+s,                PtnText+LoopTxt,      'a',   [1,0,  ExpGrpPos1,ExpGrpLen1]);
+      if PtnIdx < 18 then
+        IsMatching('Empty group in empty text '+s,  PtnText+LoopTxt,      '',    [1,0,  ExpGrpPos1,ExpGrpLen1]);
+      IsMatching('Empty group before text '+s,    PtnText+LoopTxt+'a',  'a',   [1,1,  ExpGrpPos1,ExpGrpLen1]);
+
+      if ForceMatchZeroTimes then
+        IsNotMatching('Empty group backref '+s,   PtnText+LoopTxt+'\1', 'a')
+      else
+        IsMatching('Empty group backref '+s,          PtnText+LoopTxt+'\1', 'a',   [1,0,  1,0]);
+
+      if ForceMatchZeroTimes or (PtnIdx = 18) then
+        IsNotMatching('Empty group backref in empty'+s,  PtnText+LoopTxt+'\1', '')
+      else
+        IsMatching('Empty group backref in empty'+s,  PtnText+LoopTxt+'\1', '',    [1,0,  1,0]);
+
+
+
+      if ExpGrpPos1 > 0 then ExpGrpPos1 := 2;
+      IsMatching('Empty group after text '+s,     'a'+PtnText+LoopTxt,     'a',   [1,1,  ExpGrpPos1,ExpGrpLen1]);
+
+      if PtnIdx < 18 then begin
+        IsMatching('Empty group mid   text '+s,     'a'+PtnText+LoopTxt,     'aa',  [1,1,  ExpGrpPos1,ExpGrpLen1]);
+        IsMatching('Empty group mid   text '+s,     'a'+PtnText+LoopTxt+'a', 'aa',  [1,2,  ExpGrpPos1,ExpGrpLen1]);
+
+        if ForceMatchZeroTimes then begin
+          IsNotMatching('Empty group mid + backref at end '+s,  'a'+PtnText+LoopTxt+'a\1', 'aa');
+        end
+        else begin
+          IsMatching('Empty group mid + backref at end '+s,  'a'+PtnText+LoopTxt+'a\1', 'aa',  [1,2,  2,0]);
+          IsMatching('Empty group mid + backref at end '+s,  'a'+PtnText+LoopTxt+'a(\1)', 'aa',  [1,2,  2,0,  3,0]);
+        end;
+      end;
+
+    end;
+  end;
+
+  // The backref in the loop changes each iteration. So even if the match is empty, it must be executed the correct amount of times
+  IsMatching('Empty group match-count',  '((?=.*(?:\2|a)(.))|$){1,4}', '1234567890abcdefghi',   [1,0,  1,0,  15,1]);
+  IsMatching('Empty group match-count',  '((?=.*(?:\2|a)(.))|$){1,5}', '1234567890abcdefghi',   [1,0,  1,0,  16,1]);
+
+  IsMatching('Empty group match-count',  '((?=.*(?:\2|a)(.))|$){1,4}?', '1234567890abcdefghi',   [1,0,  1,0,  12,1]);
+  IsMatching('Empty group match-count',  '((?=.*(?:\2|a)(.))|$){1,5}?', '1234567890abcdefghi',   [1,0,  1,0,  12,1]);
+
+  IsMatching('Empty group match-count',  '((?=.*(?:\2|a)(.))|$)+', '1234567890abcdefghi',   [1,0,  1,0,  12,1]);
+  IsMatching('Empty group match-count',  '((?=.*(?:\2|a)(.))|$)+?', '1234567890abcdefghi',   [1,0,  1,0,  12,1]);
+  IsMatching('Empty group match-count',  '((?=.*(?:\2|a)(.))|$)*', '1234567890abcdefghi',   [1,0,  1,0,  12,1]);
+
+  IsMatching('Empty group match-count',  '((?=.*(?:\2|a)(.))|$)*?', '1234567890abcdefghi',   [1,0,  -1,-1,  -1,-1]);
 
 
 end;


### PR DESCRIPTION
Instead of using InvertCase which may uppercase an already uppercased char, make sure the code knows the case of the letter. 
During parsing store the text-to-match all uppercase, and then during matching always lowercase.

```

                                                        Time     | Match count
==============================================================================
regexpr.pas:
                                        /Twain/ :          36 ms |        2388
                                    /(?i)Twain/ :          62 ms |        2657
                                   /[a-z]shing/ :         239 ms |        1877
                   /Huck[a-zA-Z]+|Saw[a-zA-Z]+/ :          31 ms |         396
                                            /./ :         427 ms |    18905427
                                          /(.)/ :         672 ms |    18905427
                                            /e/ :          78 ms |     1781425
                                          /(e)/ :         104 ms |     1781425
                                 /(?s).{1,45} / :          36 ms |      475715
                               /(?s)\G.{1,45} / :         166 ms |       10616
                               /\G(?s).{1,45} / :          15 ms |       10616
                                /(?s).{1,45}? / :         161 ms |     3241534
                              /(?s)\G.{1,45}? / :         166 ms |       69431
                              /\G(?s).{1,45}? / :          15 ms |       69431
                                    /\b\w+nn\b/ :         245 ms |         359
                             /[a-q][^u-z]{13}x/ :         687 ms |        4929
                  /Tom|Sawyer|Huckleberry|Finn/ :          36 ms |        3015
              /(?i)Tom|Sawyer|Huckleberry|Finn/ :         203 ms |        4820
          /.{0,2}(Tom|Sawyer|Huckleberry|Finn)/ :        2604 ms |        3015
          /.{2,4}(Tom|Sawyer|Huckleberry|Finn)/ :        2828 ms |        2220
            /Tom.{10,25}river|river.{10,25}Tom/ :          57 ms |           2
                                 /[a-zA-Z]+ing/ :         640 ms |       95863
                        /\s[a-zA-Z]{0,12}ing\s/ :         265 ms |       67810
                /([A-Za-z]awyer|[A-Za-z]inn)\s/ :         630 ms |         313
                    /["'][^"']{0,30}[?!\.]["']/ :          78 ms |        9857
                      /Tom(.{3,3}|.{5,5})*Finn/ :        3109 ms |          11
                          /Tom(...|.....)*Finn/ :        1646 ms |          11
                         /Tom(...|.....)*?Finn/ :        1588 ms |          11
            /Tom((...|.....){2,9}\s){1,5}?Finn/ :        4208 ms |          11
            /Tom((...|.....){2,9}?\s){1,5}Finn/ :        4208 ms |          11
                              /\G(?is).(?=.*$)/ :         963 ms |    20045118
                      /\G(?is).(?=(.){1,5}?$)?/ :        3515 ms |    20045118
                             /\G(?is).(?=.*+$)/ :         922 ms |    20045118
      /\G(?is).{10,10}(?=(e|y|on|fin|.){0,20})/ :        2599 ms |     2004511
    /\G(?is).{10,10}(?=(?>e|y|on|fin|.){0,20})/ :        2599 ms |     2004511
                                /Tom(?!.*Finn)/ :          36 ms |        2441
Total:                                                  35886 ms |
```