### PR TITLE
Optimize branch 

### DIFF
--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -524,6 +524,9 @@ type
     // regnode - emit a node, return location
     function EmitNode(op: TREOp): PRegExprChar;
 
+    // emit OP_BRANCH (and fillchars)
+    function EmitBranch: PRegExprChar;
+
     // emit (if appropriate) a byte of code
     procedure EmitC(ch: REChar); {$IFDEF InlineFuncs}inline;{$ENDIF}
 
@@ -1000,6 +1003,8 @@ const
   // size of BRACES arguments in REChars
   {$ENDIF}
   RENumberSz = SizeOf(LongInt) div SizeOf(REChar);
+
+  REBranchArgSz = 2; // 2 * (REChar div REChar)
 
 type
   TReGroupIndex = LongInt;
@@ -1706,6 +1711,10 @@ const
 
   OP_SUBCALL = TREOp(65); // Call of subroutine; OP_SUBCALL+i is for group i
   OP_LOOP_POSS = TREOp(66); // Same as OP_LOOP but in non-greedy mode
+
+  OP_GBRANCH = TREOp(67); // Guarded branch
+  OP_GBRANCH_EX = TREOp(68);
+  OP_GBRANCH_EX_CI = TREOp(69);
 
   OP_NONE = High(TREOp);
 
@@ -2527,9 +2536,12 @@ procedure TRegExpr.OpTail(p: PRegExprChar; val: PRegExprChar);
 // regtail on operand of first argument; nop if operandless
 begin
   // "Operandless" and "op != OP_BRANCH" are synonymous in practice.
-  if (p = nil) or (p = @regDummy) or (PREOp(p)^ <> OP_BRANCH) then
+  if (p = nil) or (p = @regDummy) or
+     (PREOp(p)^ <> OP_BRANCH) and (PREOp(p)^ <> OP_GBRANCH) and
+     (PREOp(p)^ <> OP_GBRANCH_EX) and (PREOp(p)^ <> OP_GBRANCH_EX_CI)
+  then
     Exit;
-  Tail(p + REOpSz + RENextOffSz, val);
+  Tail(p + REOpSz + RENextOffSz + REBranchArgSz, val);
 end; { of procedure TRegExpr.OpTail
   -------------------------------------------------------------- }
 
@@ -2559,6 +2571,13 @@ begin
     // compute code size without code generation
 end; { of function TRegExpr.EmitNode
   -------------------------------------------------------------- }
+
+function TRegExpr.EmitBranch: PRegExprChar;
+begin
+  Result := EmitNode(OP_BRANCH);
+  EmitC(#0);
+  EmitC(#0);
+end;
 
 procedure TRegExpr.EmitC(ch: REChar);
 begin
@@ -3176,7 +3195,7 @@ begin
     scan := regCodeWork; // First OP_BRANCH.
     if PREOp(regNext(scan))^ = OP_EEND then
     begin // Only one top-level choice.
-      scan := scan + REOpSz + RENextOffSz;
+      scan := scan + REOpSz + RENextOffSz + REBranchArgSz;
 
       // Starting-point info.
       if PREOp(scan)^ = OP_BOL then
@@ -3267,10 +3286,11 @@ function TRegExpr.DoParseReg(InBrackets, IndexBrackets: Boolean;
 // is a trifle forced, but the need to tie the tails of the branches to what
 // follows makes it hard to avoid.
 var
-  ret, br, ender: PRegExprChar;
+  ret, br, ender, brStart: PRegExprChar;
   NBrackets: Integer;
   FlagTemp: Integer;
   SavedModifiers: TRegExprModifiers;
+  HasGBranch, HasChoice: Boolean;
 begin
   Result := nil;
   FlagTemp := 0;
@@ -3302,6 +3322,7 @@ begin
 
   // Pick up the branches, linking them together.
   br := ParseBranch(FlagTemp);
+  brStart := br;
   if br = nil then
   begin
     Result := nil;
@@ -3314,6 +3335,8 @@ begin
   if (FlagTemp and FLAG_HASWIDTH) = 0 then
     FlagParse := FlagParse and not FLAG_HASWIDTH;
   FlagParse := FlagParse or FlagTemp and (FLAG_SPECSTART or FLAG_LOOP or FLAG_GREEDY);
+  HasGBranch := False;
+  HasChoice := regParse^ = '|';
   while (regParse^ = '|') do
   begin
     Inc(regParse);
@@ -3323,10 +3346,21 @@ begin
       Result := nil;
       Exit;
     end;
+    if br^ <> OP_BRANCH then
+      HasGBranch := True;
     Tail(ret, br); // OP_BRANCH -> OP_BRANCH.
     if (FlagTemp and FLAG_HASWIDTH) = 0 then
       FlagParse := FlagParse and not FLAG_HASWIDTH;
     FlagParse := FlagParse or FlagTemp and (FLAG_SPECSTART or FLAG_LOOP or FLAG_GREEDY);
+  end;
+  if fSecondPass then begin
+    if HasGBranch then begin
+      if brStart^ = OP_BRANCH then
+        brStart^ := OP_GBRANCH;
+    end
+    else
+    if not HasChoice then
+      brStart^ := OP_BRANCH;
   end;
 
   // Make a closing node, and hook it on the end.
@@ -3375,12 +3409,13 @@ function TRegExpr.ParseBranch(var FlagParse: Integer): PRegExprChar;
 // Implements the concatenation operator.
 var
   ret, chain, latest: PRegExprChar;
+  ch: REChar;
   FlagTemp: Integer;
 begin
   FlagTemp := 0;
   FlagParse := FLAG_WORST; // Tentatively.
 
-  ret := EmitNode(OP_BRANCH);
+  ret := EmitBranch;
   chain := nil;
   while (regParse < fRegexEnd) and (regParse^ <> '|') and (regParse^ <> ')') do
   begin
@@ -3392,8 +3427,26 @@ begin
     end;
     FlagParse := FlagParse or FlagTemp and (FLAG_HASWIDTH or FLAG_LOOP or FLAG_GREEDY);
     if chain = nil // First piece.
-    then
-      FlagParse := FlagParse or FlagTemp and FLAG_SPECSTART
+    then begin
+      FlagParse := FlagParse or FlagTemp and FLAG_SPECSTART;
+      if fSecondPass then begin
+        case latest^ of
+          OP_EXACTLY: begin
+              ret^ := OP_GBRANCH_EX;
+              ch := (latest + REOpSz + RENextOffSz + RENumberSz)^;
+              (ret + REOpSz + RENextOffSz)^ := ch;
+            end;
+          OP_EXACTLY_CI: begin
+              ret^ := OP_GBRANCH_EX_CI;
+              ch := (latest + REOpSz + RENextOffSz + RENumberSz)^;
+              (ret + REOpSz + RENextOffSz)^ := _UpperCase(ch);
+              (ret + REOpSz + RENextOffSz + 1)^ := _LowerCase(ch);
+            end;
+        end;
+      end
+      else begin
+      end;
+    end
     else
       Tail(chain, latest);
     chain := latest;
@@ -3642,10 +3695,10 @@ begin
             EmitComplexBraces(0, MaxBracesArg, NonGreedyOp, PossessiveCh)
           else
           begin // Emit x* as (x&|), where & means "self".
-            InsertOperator(OP_BRANCH, Result, REOpSz + RENextOffSz); // Either x
+            InsertOperator(OP_BRANCH, Result, REOpSz + RENextOffSz + REBranchArgSz); // Either x
             OpTail(Result, EmitNode(OP_BACK)); // and loop
             OpTail(Result, Result); // back
-            Tail(Result, EmitNode(OP_BRANCH)); // or
+            Tail(Result, EmitBranch); // or
             Tail(Result, EmitNode(OP_NOTHING)); // nil.
           end
         end
@@ -3690,10 +3743,10 @@ begin
             EmitComplexBraces(1, MaxBracesArg, NonGreedyOp, PossessiveCh)
           else
           begin // Emit x+ as x(&|), where & means "self".
-            NextNode := EmitNode(OP_BRANCH); // Either
+            NextNode := EmitBranch; // Either
             Tail(Result, NextNode);
             Tail(EmitNode(OP_BACK), Result); // loop back
-            Tail(NextNode, EmitNode(OP_BRANCH)); // or
+            Tail(NextNode, EmitBranch); // or
             Tail(Result, EmitNode(OP_NOTHING)); // nil.
           end
         end
@@ -3739,8 +3792,8 @@ begin
         end
         else
         begin // greedy '?'
-          InsertOperator(OP_BRANCH, Result, REOpSz + RENextOffSz); // Either x
-          Tail(Result, EmitNode(OP_BRANCH)); // or
+          InsertOperator(OP_BRANCH, Result, REOpSz + RENextOffSz + REBranchArgSz); // Either x
+          Tail(Result, EmitBranch); // or
           NextNode := EmitNode(OP_NOTHING); // nil.
           Tail(Result, NextNode);
           OpTail(Result, NextNode);
@@ -5954,14 +6007,14 @@ begin
 
       OP_BRANCH:
         begin
-          if (next^ <> OP_BRANCH) // No next choice in group
+          if (next^ <> OP_BRANCH)  // No next choice in group
           then
-            next := scan + REOpSz + RENextOffSz // Avoid recursion
+            next := scan + REOpSz + RENextOffSz + REBranchArgSz // Avoid recursion
           else
           begin
             repeat
               save := regInput;
-              Result := MatchPrim(scan + REOpSz + RENextOffSz);
+              Result := MatchPrim(scan + REOpSz + RENextOffSz + REBranchArgSz);
               if Result then
                 Exit;
               // if branch worked until OP_CLOSE, and marked atomic group as "done", then exit
@@ -5974,8 +6027,50 @@ begin
               if  (next^ <> OP_BRANCH) then
                 break;
             until  False;
-            next := scan  + REOpSz + RENextOffSz;
+            next := scan + REOpSz + RENextOffSz + REBranchArgSz; // Avoid recursion
           end;
+        end;
+
+      OP_GBRANCH, OP_GBRANCH_EX, OP_GBRANCH_EX_CI:
+        begin
+          Assert((next^ = OP_BRANCH) or (next^ = OP_GBRANCH) or (next^ = OP_GBRANCH_EX) or (next^ = OP_GBRANCH_EX_CI));
+          repeat
+            save := regInput;
+            case scan^ of
+              OP_GBRANCH, OP_BRANCH:
+                Result := MatchPrim(scan + REOpSz + RENextOffSz + REBranchArgSz);
+              OP_GBRANCH_EX:
+                if (regInput^ = (scan + REOpSz + RENextOffSz)^) then
+                  Result := MatchPrim(scan + REOpSz + RENextOffSz + REBranchArgSz);
+              OP_GBRANCH_EX_CI:
+                if (regInput^ = (scan + REOpSz + RENextOffSz)^) or
+                   (regInput^ = (scan + REOpSz + RENextOffSz + 1)^)
+                then
+                  Result := MatchPrim(scan + REOpSz + RENextOffSz + REBranchArgSz);
+            end;
+            if Result then
+              Exit;
+            // if branch worked until OP_CLOSE, and marked atomic group as "done", then exit
+            regInput := save;
+            if IsBacktrackingGroupAsAtom then
+              Exit;
+            scan := next;
+            Assert(scan <> nil);
+            next := regNextQuick(scan);
+            if  (next^ <> OP_BRANCH) and (next^ <> OP_GBRANCH) and (next^ <> OP_GBRANCH_EX) and (next^ <> OP_GBRANCH_EX_CI) then
+              break;
+          until  False;
+          case scan^ of
+            OP_GBRANCH_EX:
+              if (regInput^ <> (scan + REOpSz + RENextOffSz)^) then
+                exit;
+            OP_GBRANCH_EX_CI:
+              if (regInput^ <> (scan + REOpSz + RENextOffSz)^) and
+                 (regInput^ <> (scan + REOpSz + RENextOffSz + 1)^)
+              then
+                exit;
+          end;
+          next := scan + REOpSz + RENextOffSz + REBranchArgSz; // Avoid recursion
         end;
 
       {$IFDEF ComplexBraces}
@@ -7114,17 +7209,20 @@ begin
       OP_LOOKAROUND_OPTIONAL:
         ;
 
-      OP_BRANCH:
+      OP_BRANCH, OP_GBRANCH, OP_GBRANCH_EX, OP_GBRANCH_EX_CI:
         begin
-          if (PREOp(Next)^ <> OP_BRANCH) // No choice.
+          if (PREOp(Next)^ <> OP_BRANCH) and (PREOp(Next)^ <> OP_GBRANCH) and
+             (PREOp(Next)^ <> OP_GBRANCH_EX) and (PREOp(Next)^ <> OP_GBRANCH_EX_CI) // No choice.
           then
-            Next := scan + REOpSz + RENextOffSz // Avoid recursion.
+            Next := scan + REOpSz + RENextOffSz + REBranchArgSz // Avoid recursion.
           else
           begin
             repeat
-              FillFirstCharSet(scan + REOpSz + RENextOffSz);
+              FillFirstCharSet(scan + REOpSz + RENextOffSz + REBranchArgSz);
               scan := regNextQuick(scan);
-            until (scan = nil) or (PREOp(scan)^ <> OP_BRANCH);
+            until (scan = nil) or
+              ( (PREOp(scan)^ <> OP_BRANCH) and (PREOp(Next)^ <> OP_GBRANCH) and
+                (PREOp(scan)^ <> OP_GBRANCH_EX) and (PREOp(scan)^ <> OP_GBRANCH_EX_CI) );
             Exit;
           end;
         end;
@@ -7402,6 +7500,12 @@ begin
       Result := 'ANYBUT_CI';
     OP_BRANCH:
       Result := 'BRANCH';
+    OP_GBRANCH:
+      Result := 'G_BRANCH';
+    OP_GBRANCH_EX:
+      Result := 'G_BRANCH_EX';
+    OP_GBRANCH_EX_CI:
+      Result := 'G_BRANCH_EX_CI';
     OP_EXACTLY:
       Result := 'EXACTLY';
     OP_EXACTLY_CI:
@@ -7697,6 +7801,13 @@ begin
                + ' Len: ' + IntToStr(PReOpLookBehindOptions(s)^.MatchLenMin)
                + '..' + IntToStr(PReOpLookBehindOptions(s)^.MatchLenMax);
       Inc(s, ReOpLookBehindOptionsSz);
+    end
+    else
+    if (op = OP_BRANCH) or (op = OP_GBRANCH) or
+       (op = OP_GBRANCH_EX) or (op = OP_GBRANCH_EX_CI)
+    then
+    begin
+      Inc(s, REBranchArgSz);
     end;
     Result := Result + #$d#$a;
   end; { of while }
@@ -7818,9 +7929,10 @@ begin
           Exit;
         end;
 
-      OP_BRANCH:
+      OP_BRANCH, OP_GBRANCH, OP_GBRANCH_EX, OP_GBRANCH_EX_CI:
         begin
-          if next^ = OP_BRANCH then begin
+          if (next^ = OP_BRANCH) or (PREOp(Next)^ = OP_GBRANCH) or (next^ = OP_GBRANCH_EX) or (next^ = OP_GBRANCH_EX_CI) then begin
+            s := s + REBranchArgSz;
             if not IsPartFixedLength(s, op, ABranchLen, ABranchMaxLen, OP_EEND, next, []) then
             begin
               if not NotFixedLen then
@@ -7832,6 +7944,7 @@ begin
             s := next;
             repeat
               next := regNext(s);
+              s := s + REBranchArgSz;
               Inc(s, REOpSz + RENextOffSz);
               if not IsPartFixedLength(s, op, ASubLen, ASubMaxLen, OP_EEND, next, []) then
               begin
@@ -7848,10 +7961,13 @@ begin
                 ABranchLen := ASubLen;
               if ASubMaxLen > ABranchMaxLen then
                 ABranchMaxLen := ASubMaxLen;
-            until next^ <> OP_BRANCH;
+            until (next^ <> OP_BRANCH) and (next^ <> OP_GBRANCH) and
+                  (next^ <> OP_GBRANCH_EX) and (next^ <> OP_GBRANCH_EX_CI);
             AMinLen := AMinLen + ABranchLen;
             IncMaxLen(FndMaxLen, ABranchMaxLen);
-          end;
+          end
+          else
+            s := s + REBranchArgSz;
         end;
 
       OP_OPEN:

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -2716,6 +2716,9 @@ begin
     place^ := #0;
     Inc(place);
   end;
+  for i := 0 to regNumBrackets - 1 do
+    if (GrpOpCodes[i] <> nil) and (GrpOpCodes[i] >= opnd) then
+      GrpOpCodes[i] := GrpOpCodes[i] + sz;
 end; { of procedure TRegExpr.InsertOperator
   -------------------------------------------------------------- }
 
@@ -7644,7 +7647,7 @@ begin
     end;
     if (op = OP_SUBCALL) then
     begin
-      Result := Result + ' (?' + IntToStr(PReGroupIndex(s)^) + ')';
+      Result := Result + ' (?' + IntToStr(PReGroupIndex(s)^) + ') @'  + IntToStr(GrpOpCodes[PReGroupIndex(s)^]-programm);
       Inc(s, ReGroupIndexSz);
     end;
     if (op = OP_OPEN) or (op = OP_OPEN_ATOMIC) or (op = OP_CLOSE) or (op = OP_CLOSE_ATOMIC) then

--- a/test/tests.pas
+++ b/test/tests.pas
@@ -1662,6 +1662,8 @@ begin
   IsMatching('Valid call idx', '(.)(.)(?2)',  'aABBC',  [1,3,  1,1, 2,1]);
   TestBadRegex('Invalid call idx', '(.)(.)(?3)');
 
+  IsMatching('ref in branch', '((A)|B|C\2)*',  'AACACB',  [1,4,  3,2, 2,1]);
+  IsMatching('ref in call', '[^A]*((A)|B|C\2)*',  'DAACACBE',  [1,5,  4,2, 3,1]);
 end;
 
 procedure TTestRegexpr.TestSubCall;
@@ -1681,6 +1683,9 @@ begin
   IsMatching('nested call to outer', '(1(2(3(?1)?))A)_((?3))',  '123A_3123',  [1,6,  1,4, 2,2, 3,1, 6,1]);
   IsMatching('nested call to outer', '(1(2(3(?1)?))A)_((?3))',  '123A_3123A',  [1,10,  1,4, 2,2, 3,1, 6,5]);
 
+  IsMatching('ref in branch', '((A)|B|C(?2))*',  'AACACB',  [1,4,  3,2, 2,1]);
+  IsMatching('ref in branch', '[^A]*((A)|B|C(?2))*',  'DAACACBE',  [1,5,  4,2, 3,1]);
+  IsMatching('ref in branch', '((A)|B|C(?2))+',  'AACB',  [1,2,  2,1, 2,1]);
 end;
 
 procedure TTestRegexpr.TestNamedGroups;


### PR DESCRIPTION
Optimize `|` branches

Fix for bug #352 

```

                                                        Time     Before | Opt-Branch     | Match count
========================================================================================================
                                                  /Twain/ :       41 ms |      37 ms     |      2388
                                              /(?i)Twain/ :       58 ms |      58 ms     |      2657
                                             /[a-z]shing/ :      228 ms |     228 ms     |      1877
                             /Huck[a-zA-Z]+|Saw[a-zA-Z]+/ :       39 ms |      35 ms     |       396
                                                      /./ :      421 ms |     449 ms     |  18905427
                                                    /(.)/ :      660 ms |     707 ms     |  18905427
                                                      /e/ :       84 ms |      80 ms     |   1781425
                                                    /(e)/ :      105 ms |     103 ms     |   1781425
                                           /(?s).{1,45} / :       37 ms |      37 ms     |    475715
                                         /(?s)\G.{1,45} / :      164 ms |     144 ms     |     10616
                                         /\G(?s).{1,45} / :       15 ms |      15 ms     |     10616
                                          /(?s).{1,45}? / :      154 ms |     160 ms     |   3241534
                                        /(?s)\G.{1,45}? / :      169 ms |     146 ms     |     69431
                                        /\G(?s).{1,45}? / :       19 ms |      19 ms     |     69431
                                              /\b\w+nn\b/ :      230 ms |     226 ms     |       359
                                       /[a-q][^u-z]{13}x/ :      652 ms |     613 ms     |      4929
                            /Tom|Sawyer|Huckleberry|Finn/ :       42 ms |      39 ms     |      3015
                        /(?i)Tom|Sawyer|Huckleberry|Finn/ :      164 ms |     142 ms +   |      4820
                    /.{0,2}(Tom|Sawyer|Huckleberry|Finn)/ :     2123 ms |    1636 ms +++ |      3015
                    /.{2,4}(Tom|Sawyer|Huckleberry|Finn)/ :     2330 ms |    1820 ms +++ |      2220
                      /Tom.{10,25}river|river.{10,25}Tom/ :       56 ms |      50 ms     |         2
                                           /[a-zA-Z]+ing/ :      585 ms |     574 ms     |     95863
                                  /\s[a-zA-Z]{0,12}ing\s/ :      261 ms |     257 ms     |     67810
                          /([A-Za-z]awyer|[A-Za-z]inn)\s/ :      527 ms |     521 ms     |       313
                              /["'][^"']{0,30}[?!\.]["']/ :       80 ms |      74 ms     |      9857
                                /Tom(.{3,3}|.{5,5})*Finn/ :     2748 ms |    2724 ms     |        11
                                    /Tom(...|.....)*Finn/ :     1271 ms |    1277 ms     |        11
                                   /Tom(...|.....)*?Finn/ :     1380 ms |    1337 ms     |        11
                      /Tom((...|.....){2,9}\s){1,5}?Finn/ :     3638 ms |    3603 ms     |        11
                      /Tom((...|.....){2,9}?\s){1,5}Finn/ :     3613 ms |    3605 ms     |        11
                                        /\G(?is).(?=.*$)/ :      916 ms |     947 ms     |  20045118
                                /\G(?is).(?=(.){1,5}?$)?/ :     3293 ms |    3302 ms     |  20045118
                                       /\G(?is).(?=.*+$)/ :      880 ms |     933 ms     |  20045118
                /\G(?is).{10,10}(?=(e|y|on|fin|.){0,20})/ :     1834 ms |    1408 ms +++ |   2004511
              /\G(?is).{10,10}(?=(?>e|y|on|fin|.){0,20})/ :     1837 ms |    1414 ms +++ |   2004511
                                          /Tom(?!.*Finn)/ :       41 ms |      37 ms     |      2441
     /(?i)(?>[aeoui][bcdfghjklmnpqrstvwxyz \r\n]*){1,40}/ :      597 ms |     576 ms     |    579843
                          /(?i)[ bdlm][abdegij][mnoprst]/ :      224 ms |     214 ms     |    788955
Total:                                                         31531 ms |   29562 ms     |
``` 