### PR TITLE
First charset

### DIFF
--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -6493,12 +6493,6 @@ begin
   regNestedCalls := 0;
   regRecursion := 0;
   fInputCurrentEnd := fInputEnd;
-  Result := False;
-  {$IFDEF RegExpWithStackOverflowCheck_DecStack_Frame}
-  StackLimit := StackBottom;
-  if StackLimit <> nil then
-    StackLimit := StackLimit + 36000; // Add for any calls within the current MatchPrim // FPC has "STACK_MARGIN = 16384;", but we need to call Error, ..., raise
-  {$ENDIF}
   Result := MatchPrim(regCodeWork);
   if Result then
   begin
@@ -6627,6 +6621,12 @@ begin
     if regMustString <> '' then
       if StrLPos(fInputStart, PRegExprChar(regMustString), fInputEnd - fInputStart, length(regMustString)) = nil then
         exit;
+
+  {$IFDEF RegExpWithStackOverflowCheck_DecStack_Frame}
+  StackLimit := StackBottom;
+  if StackLimit <> nil then
+    StackLimit := StackLimit + 36000; // Add for any calls within the current MatchPrim // FPC has "STACK_MARGIN = 16384;", but we need to call Error, ..., raise
+  {$ENDIF}
 
   FMatchesCleared := False;
   // ATryOnce or anchored match (it needs to be tried only once).

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -361,7 +361,7 @@ type
     regMustLen: Integer; // length of regMust string
     regMustString: RegExprString; // string which must occur in match (got from regMust/regMustLen)
     LookAroundInfoList: PRegExprLookAroundInfo;
-    regNestedCalls: Integer; // some attempt to prevent 'catastrophic backtracking' but not used
+    //regNestedCalls: integer; // some attempt to prevent 'catastrophic backtracking' but not used
     CurrentSubCalled: Integer;
 
     FMinMatchLen: integer;
@@ -6490,7 +6490,7 @@ end;
 function TRegExpr.MatchAtOnePos(APos: PRegExprChar): Boolean;
 begin
   regInput := APos;
-  regNestedCalls := 0;
+  //regNestedCalls := 0;
   regRecursion := 0;
   fInputCurrentEnd := fInputEnd;
   Result := MatchPrim(regCodeWork);

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -6491,7 +6491,6 @@ function TRegExpr.MatchAtOnePos(APos: PRegExprChar): Boolean;
 begin
   regInput := APos;
   //regNestedCalls := 0;
-  regRecursion := 0;
   fInputCurrentEnd := fInputEnd;
   Result := MatchPrim(regCodeWork);
   if Result then
@@ -6521,6 +6520,7 @@ begin
   {$ENDIF}
   LookAroundInfoList := nil;
   CurrentSubCalled := -1;
+  regRecursion := 0;
 end;
 
 procedure TRegExpr.InitInternalGroupData;

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -8091,7 +8091,7 @@ begin
             if (ABranchMaxLen = high(ABranchMaxLen)) and not(flfForceToStopAt in Flags) then
               exit;
           end;
-          assert(s^=OP_CLOSE);
+          assert(s^=OP_CLOSE_ATOMIC);
           AMinLen := AMinLen + ASubLen;
           IncMaxLen(FndMaxLen, ASubMaxLen);
           Inc(s, REOpSz + RENextOffSz + ReGroupIndexSz); // consume the OP_CLOSE_ATOMIC;


### PR DESCRIPTION
For a regex `(?=abc)` the "a" from the look ahead is a valid first char.

Further `(?=[abc])[ced]` can only have "c" as first char (otherwise either the lookahead, or the main expression will fail)

---

I did forgot some code when I optimized the branches. Since dummy (non-choice) branches are now removed, there no longer is a need to check for them.