### PR TITLE
Optimize op call

### DIFF
--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -5914,8 +5914,9 @@ begin
               if (next^ = OP_LOOKAROUND_OPTIONAL) then
                 next := PRegExprChar(AlignToPtr(next + 1)) + RENextOffSz;
               regInput := Local.LookAroundInfo.InputPos;
-              Result := MatchPrim(next);
-              Exit;
+              Result := False;
+              scan := next;
+              continue;
             end;
           end
           else
@@ -5925,8 +5926,9 @@ begin
               if (next^ = OP_LOOKAROUND_OPTIONAL) then
                 next := PRegExprChar(AlignToPtr(next + 1)) + RENextOffSz;
               regInput := Local.LookAroundInfo.InputPos;
-              Result := MatchPrim(next);
-              Exit;
+              Result := False;
+              scan := next;
+              continue;
             end;
           end;
 
@@ -6002,8 +6004,9 @@ begin
               if (next^ = OP_LOOKAROUND_OPTIONAL) then
                 next := PRegExprChar(AlignToPtr(next + 1)) + RENextOffSz;
               regInput := Local.LookAroundInfo.InputPos;
-              Result := MatchPrim(next);
-              Exit;
+              Result := False;
+              scan := next;
+              continue;
             end;
           end
           else
@@ -6013,8 +6016,9 @@ begin
               if (next^ = OP_LOOKAROUND_OPTIONAL) then
                 next := PRegExprChar(AlignToPtr(next + 1)) + RENextOffSz;
               regInput := Local.LookAroundInfo.InputPos;
-              Result := MatchPrim(next);
-              Exit;
+              Result := False;
+              scan := next;
+              continue;
             end;
           end;
 
@@ -6353,8 +6357,10 @@ begin
           end;
           no := FindRepeated(opnd, BracesMax);
           if no >= BracesMin then
-            if (nextch = #0) or (regInput^ = nextch) then
-              Result := MatchPrim(next);
+            if (nextch = #0) or (regInput^ = nextch) then begin
+              scan := next;
+              continue;
+            end;
           Exit;
         end;
 

--- a/test/tests.pas
+++ b/test/tests.pas
@@ -88,6 +88,7 @@ type
     procedure TestRegLookAhead;
     procedure TestRegLookBehind;
     procedure TestRegLookAroundMixed;
+    procedure TestResetMatchPos;
     {$IFDEF OverMeth}
     procedure TestReplaceOverload;
     {$ENDIF}
@@ -2708,6 +2709,40 @@ begin
                 '(?<=^(?=.*$).*)B',        '_A_1_B_AxyzB123_A_',     [6,1]);
 
   IsNotMatching('behind not found before "A=2" for dot', '(?=A).(?<=2)',    'A2AB34AB_');
+
+end;
+
+procedure TTestRegexpr.TestResetMatchPos;
+begin
+  IsMatching('Set Matchstart middle',          'a\Kb',  'ab',    [2,1]);
+  IsMatching('Set Matchstart end of match',    'a\K',   'ab',    [2,0]);
+  IsMatching('Set Matchstart begin of match',  '\Ka',   'ab',    [1,1]);
+  IsMatching('Set Matchstart stand-alone',     '\K',    'ab',    [1,0]);
+
+  IsMatching('Set Matchstart middle',          'a\Kb',  'xab',    [3,1]);
+  IsMatching('Set Matchstart end of match',    'a\K',   'xab',    [3,0]);
+  IsMatching('Set Matchstart begin of match',  '\Ka',   'xab',    [2,1]);
+  IsMatching('Set Matchstart stand-alone',     '\K',    'xab',    [1,0]);
+  IsMatching('Set Matchstart stand-alone with offset',  '\K',    'xabde',    [3,0], 3);
+
+  IsMatching('Set Matchstart EOL',     '$\K',    'xab',    [4,0]);
+  IsMatching('Set Matchstart EOL',     '\K$',    'xab',    [4,0]);
+
+
+  IsMatching('backtracking',     '(?:.\K)*?b',    'xabc',    [3,1]);
+  IsMatching('backtracking',     '(?:.\K)*b',     'xabc',    [3,1]);
+
+
+  IsMatching('backtracking',     '^(?=.*\Kx)?.*c',    'abcd',    [1,3]);
+  IsMatching('backtracking',     '^(?=\K.*x)?.*c',    'abcd',    [1,3]);
+  IsMatching('backtracking',     '^(?:.*\Kx)?.*c',    'abcd',    [1,3]);
+  IsMatching('backtracking',     '^(?:\K.*x)?.*c',    'abcd',    [1,3]);
+
+  IsMatching('multiple \K',     '^a\Kb\Kc',    'abcd',    [3,1]);
+
+  IsNotMatching('lookahead not possible',   '^(?=.*\K).*c',    'abcd');
+  IsMatching('lookahead',   '^(?=.\K).*c',    'abcd',    [2,2]);
+  IsMatching('lookbehind',  '(?<=\K.)c',    'abcd',    [2,2]);
 
 end;
 

--- a/test/tests.pas
+++ b/test/tests.pas
@@ -80,6 +80,7 @@ type
     procedure TestReferences;
     procedure TestSubCall;
     procedure TestNamedGroups;
+    procedure TestCaptures;
     procedure TestRecurseAndCaptures;
     procedure TestIsFixedLength;
     procedure TestMatchBefore;
@@ -1802,6 +1803,34 @@ begin
 
 
 
+end;
+
+procedure TTestRegexpr.TestCaptures;
+begin
+  IsMatching('simple capture', '(a)',    'abc',  [1,1,  1,1]);
+  IsMatching('simple capture', '(b)',    'abc',  [2,1,  2,1]);
+  IsMatching('simple capture', '(c)',    'abc',  [3,1,  3,1]);
+  IsMatching('simple capture .', '(.)',  'abc',  [1,1,  1,1]);
+
+  IsMatching('capture optional content',    '(d?)',  'abc',  [1,0,  1,0]);
+  IsMatching('optional capture not found',  '(d)?',  'abc',  [1,0,  -1,-1]);
+  IsMatching('optional capture found',      '(a)?',  'abc',  [1,1,  1,1]);
+
+  IsMatching('zero width capture', '(^)',    'abc',  [1,0,  1,0]);
+  IsMatching('zero width capture', '($)',    'abc',  [4,0,  4,0]);
+  IsMatching('zero width capture', '(\b)',   'abc',  [1,0,  1,0]);
+  IsMatching('zero width capture', '(\b).',  'abc',  [1,1,  1,0]);
+
+  IsMatching('backtracking', '(ad)',  'abcade',  [4,2,  4,2]);
+  IsMatching('backtracking', '^.*(a)',   'abcade',  [1,4,  4,1]);
+  IsMatching('backtracking', '^.*(a)b',  'abcade',  [1,2,  1,1]);
+  IsMatching('backtracking', '^.*(ab)',   'abcade',  [1,2,  1,2]);
+
+  IsMatching('backtracking', '(ad)*',  'adadae',  [1,4,  3,2]);
+
+  IsMatching('backtracking many', '^.*(a).(b)c',  'a.bda.bc',     [1,8,  5,1, 7,1]);
+  IsMatching('backtracking many', '^.*?(a).(b)c',  'a.bda.bc',    [1,8,  5,1, 7,1]);
+  IsMatching('backtracking many', '^.*?(a).*?(b)c',  'a.bda.bc',  [1,8,  1,1, 7,1]);
 end;
 
 procedure TTestRegexpr.TestRecurseAndCaptures;


### PR DESCRIPTION
OP_CLOSE (of OP_OPEN / normal capture) does not need to recurse. The backtracking can be handled entirely in OP_OPEN (the bounds will anyway not be valid until OP_OPEN restored the GrpStart, so we can defer GrpEnd untill then).

----

There were several occurrences of
```
     Result := MatchPrim(next);
     Exit;
```

If we continue the while-loop at the current level it will return the same result.



```
                                                           Time     Before |    OP_OPEN     |       exit     | Match count
==================================================================================================================
                                                  /Twain/ :          31 ms |      23 ms     |      23 ms     |       2388
                                              /(?i)Twain/ :          46 ms |      39 ms     |      47 ms     |       2657
                                             /[a-z]shing/ :         203 ms |     203 ms     |     203 ms     |       1877
                             /Huck[a-zA-Z]+|Saw[a-zA-Z]+/ :          23 ms |      31 ms     |      23 ms     |        396
                                                      /./ :         422 ms |     406 ms     |     398 ms     |   18905427
                                                    /(.)/ :         594 ms |     547 ms     |     547 ms     |   18905427
                                                      /e/ :          78 ms |      70 ms     |      78 ms     |    1781425
                                                    /(e)/ :          86 ms |      86 ms     |      86 ms     |    1781425
                                           /(?s).{1,45} / :          31 ms |      39 ms     |      31 ms     |     475715
                                         /(?s)\G.{1,45} / :          15 ms |      15 ms     |      16 ms     |      10616
                                         /\G(?s).{1,45} / :          16 ms |      15 ms     |      15 ms     |      10616
                                          /(?s).{1,45}? / :         148 ms |     156 ms     |     148 ms     |    3241534
                                        /(?s)\G.{1,45}? / :          15 ms |      15 ms     |      15 ms     |      69431
                                        /\G(?s).{1,45}? / :          16 ms |      15 ms     |      15 ms     |      69431
                                              /\b\w+nn\b/ :         203 ms |     195 ms     |     195 ms     |        359
                                       /[a-q][^u-z]{13}x/ :         609 ms |     609 ms     |     617 ms     |       4929
                            /Tom|Sawyer|Huckleberry|Finn/ :          31 ms |      31 ms     |      31 ms     |       3015
                        /(?i)Tom|Sawyer|Huckleberry|Finn/ :         125 ms |     133 ms     |     133 ms     |       4820
                    /.{0,2}(Tom|Sawyer|Huckleberry|Finn)/ :        1632 ms |    1656 ms     |    1679 ms     |       3015
                    /.{2,4}(Tom|Sawyer|Huckleberry|Finn)/ :        1859 ms |    1867 ms     |    1891 ms     |       2220
                      /Tom.{10,25}river|river.{10,25}Tom/ :          39 ms |      39 ms     |      46 ms     |          2
                                           /[a-zA-Z]+ing/ :         547 ms |     523 ms     |     539 ms     |      95863
                                  /\s[a-zA-Z]{0,12}ing\s/ :         242 ms |     242 ms     |     242 ms     |      67810
                          /([A-Za-z]awyer|[A-Za-z]inn)\s/ :         500 ms |     516 ms     |     515 ms     |        313
                              /["'][^"']{0,30}[?!\.]["']/ :          62 ms |      62 ms     |      62 ms     |       9857
                                /Tom(.{3,3}|.{5,5})*Finn/ :        2750 ms |    2703 ms     |    2695 ms     |         11
                                    /Tom(...|.....)*Finn/ :        1523 ms |    1132 ms +++ |    1125 ms     |         11
                                   /Tom(...|.....)*?Finn/ :        1336 ms |    1242 ms +++ |    1266 ms     |         11
                      /Tom((...|.....){2,9}\s){1,5}?Finn/ :        3593 ms |    3296 ms +++ |    3296 ms     |         11
                      /Tom((...|.....){2,9}?\s){1,5}Finn/ :        3586 ms |    3320 ms +++ |    3289 ms     |         11
                    /Tom((?:...|.....){2,9}\s){1,5}?Finn/ :        2851 ms |    2765 ms     |    2711 ms     |         11
                    /Tom((?:...|.....){2,9}?\s){1,5}Finn/ :        2812 ms |    2726 ms     |    2711 ms     |         11
                    /Tom((?>...|.....){2,9}\s){1,5}?Finn/ :          23 ms |      31 ms     |      31 ms     |          2
                    /Tom((?>...|.....){2,9}?\s){1,5}Finn/ :          31 ms |      23 ms     |      31 ms     |          2
                                        /\G(?is).(?=.*$)/ :         820 ms |     836 ms     |     804 ms +   |   20045118
                                /\G(?is).(?=(.){1,5}?$)?/ :        3101 ms |    2859 ms +++ |    2789 ms     |   20045118
                                       /\G(?is).(?=.*+$)/ :         836 ms |     875 ms     |     781 ms +++ |   20045118
                /\G(?is).{10,10}(?=(e|y|on|fin|.){0,20})/ :        1414 ms |    1234 ms +++ |    1250 ms     |    2004511
              /\G(?is).{10,10}(?=(?>e|y|on|fin|.){0,20})/ :        1406 ms |    1375 ms     |    1383 ms     |    2004511
                                          /Tom(?!.*Finn)/ :          23 ms |      31 ms     |      31 ms     |       2441
     /(?i)(?>[aeoui][bcdfghjklmnpqrstvwxyz \r\n]*){1,40}/ :         593 ms |     601 ms     |     594 ms     |     579843
                          /(?i)[ bdlm][abdegij][mnoprst]/ :         211 ms |     211 ms     |     210 ms     |     788955
Total:                                                            34491 ms |   32805 ms     |   32601 ms     |
```