### PR TITLE
Fix FillFirstCharSet with loops in branches

### DIFF
--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -7359,7 +7359,7 @@ begin
         begin
           min_cnt := PREBracesArg(AlignToPtr(Next + REOpSz + RENextOffSz))^;
           if min_cnt = 0 then begin
-            opnd := AlignToPtr(Next + REOpSz + 2 * RENextOffSz + 2 * REBracesArgSz);
+            opnd := regNext(Next);
             FillFirstCharSet(opnd); // FirstChar may be after loop
           end;
           Next := PRegExprChar(AlignToPtr(scan + 1)) + RENextOffSz;
@@ -7373,7 +7373,6 @@ begin
           if min_cnt = 0 then
             Exit;
           // zero width loop
-          Next := AlignToPtr(scan + REOpSz + 2 * RENextOffSz + 2 * REBracesArgSz);
         end;
       {$ENDIF}
 


### PR DESCRIPTION
For certain pattern (lookahead + loop + branch) the FirstCharSet was wrong

`(?:X|(?=a))+|b`

The first part up to the `|` could match either `X` or an `empty string followed by a` (match one or more times).
So for the entire pattern, first char could be in Xab.

But FirstCharset would only have Xb.

----

I added tests by creating variations of nested expressions => that leads to a big amount of tests, and therefore the runtime of the test slows done noticeable.

But on the other hand it caught the above bug. I think its worth the extra runtime.
