### PR TITLE
Lookaround fixes

### DIFF
--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -6271,8 +6271,13 @@ begin
               CurrentLoopInfoListPtr := Local.LoopInfoListPtr^.OuterLoop;
               Result := MatchPrim(next);
               CurrentLoopInfoListPtr := Local.LoopInfoListPtr;
-              if not Result then
+              if not Result then begin
                 regInput := save;
+                if (scan^ = OP_LOOP_POSS) then begin
+                  Local.LoopInfoListPtr^.BackTrackingAsAtom := True;
+                  IsBacktrackingGroupAsAtom := True;
+                end;
+              end;
               exit;
             end;
 

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -7380,22 +7380,26 @@ begin
         begin
           opnd := PRegExprChar(AlignToPtr(Next + 1)) + RENextOffSz;
           Next := regNextQuick(Next);
-          FillFirstCharSet(Next);
-          if opnd^ = OP_LOOKAROUND_OPTIONAL then
-            Exit;
 
-          Next := PRegExprChar(AlignToPtr(scan + 1)) + RENextOffSz;
-          TmpFirstCharSet := FirstCharSet;
-          FirstCharSet := [];
-          FillFirstCharSet(Next);
+          if opnd^ <> OP_LOOKAROUND_OPTIONAL then begin
+            TempSet := FirstCharSet;
+            FirstCharSet := [];
+            FillFirstCharSet(Next); // after the lookahead
 
-          if TmpFirstCharSet = [] then
+            Next := PRegExprChar(AlignToPtr(scan + 1)) + RENextOffSz;
+            TmpFirstCharSet := FirstCharSet;
+            FirstCharSet := [];
+            FillFirstCharSet(Next); // inside the lookahead
+
+            if TmpFirstCharSet = [] then
+              FirstCharSet := TempSet + FirstCharSet
+            else
+            if FirstCharSet = [] then
+              FirstCharSet := TempSet + TmpFirstCharSet
+            else
+              FirstCharSet := TempSet + (FirstCharSet * TmpFirstCharSet);
             exit;
-          if FirstCharSet = [] then
-            FirstCharSet := TmpFirstCharSet
-          else
-            FirstCharSet := FirstCharSet * TmpFirstCharSet;
-          exit;
+          end;
         end;
 
       OP_LOOKAHEAD_NEG,

--- a/test/tests.pas
+++ b/test/tests.pas
@@ -2529,6 +2529,10 @@ begin
   IsMatching('look-ahead (opt) in branch',     '^.(?:a|.(?=2)?|b)',    '.xb9',  [1,2]);
   IsMatching('look-ahead-neg (opt) in branch', '^.(?:a|.(?!.)?|b)',    '.xb9',  [1,2]);
   IsMatching('look-ahead-neg in branch',       '^.(?:a|.(?!Y)|b)',     '.xb9',  [1,2]);
+
+  // first char
+  IsMatching('',       'a*(?=[bc])[cd]',     'aacd',  [1,3]);
+
 end;
 
 procedure TTestRegexpr.TestRegLookBehind;

--- a/test/tests.pas
+++ b/test/tests.pas
@@ -2533,6 +2533,54 @@ begin
   // first char
   IsMatching('',       'a*(?=[bc])[cd]',     'aacd',  [1,3]);
 
+
+  // possesive optional lookahead
+  // ?+
+  IsMatching('look-ahead-poss-opt ? ', '^(.*?)1(?=(2))?.*x1(?!\2)',   '.12...1a...x12',  [1,13, 1,1, -1,-1]);
+  IsMatching('look-ahead-poss-opt ?+', '^(.*?)1(?=(2))?+.*x1(?!\2)',  '.12...1a...x12',  [1,13, 1,6, -1,-1]);
+  // *+
+  IsMatching('look-ahead-poss-opt * ', '^(.*?)1(?=(2))*.*x1(?!\2)',   '.12...1a...x12',  [1,13, 1,1, -1,-1]);
+  IsMatching('look-ahead-poss-opt *+', '^(.*?)1(?=(2))*+.*x1(?!\2)',  '.12...1a...x12',  [1,13, 1,6, -1,-1]);
+  // {0,1}+
+  IsMatching('look-ahead-poss-opt {0,1} ', '^(.*?)1(?=(2)){0,1}.*x1(?!\2)',   '.12...1a...x12',  [1,13, 1,1, -1,-1]);
+  IsMatching('look-ahead-poss-opt {0,1}+', '^(.*?)1(?=(2)){0,1}+.*x1(?!\2)',  '.12...1a...x12',  [1,13, 1,6, -1,-1]);
+  // {0,0}+ // no diff
+  IsMatching('look-ahead-poss-opt {0,0} ', '^(.*?)1(?=(2)){0,0}.*x1(?!\2)',  '.12...1a...x12',  [1,13, 1,1, -1,-1]);
+  IsMatching('look-ahead-poss-opt {0,0}+', '^(.*?)1(?=(2)){0,0}+.*x1(?!\2)',  '.12...1a...x12',  [1,13, 1,1, -1,-1]);
+  // {1,1}+ // no diff
+  IsNotMatching('look-ahead-poss-opt {1,1} ', '^(.*?)1(?=(2)){1,1}.*x1(?!\2)',  '.12...1a...x12');
+  IsNotMatching('look-ahead-poss-opt {1,1}+', '^(.*?)1(?=(2)){1,1}+.*x1(?!\2)',  '.12...1a...x12');
+
+  // greedy vs non greedy
+  // ? vs ??
+  IsMatching('look-ahead-opt-ng 1', '^(.*?)1(?=(2))?.*x1(?=\2)?',   '.12...1a...x12',  [1,13, 1,1, 3,1]);
+  IsMatching('look-ahead-opt-ng 2', '^(.*?)1(?=(2))??.*x1(?=\2)?',   '.12...1a...x12',  [1,13, 1,1, -1,-1]);
+  IsMatching('look-ahead-opt-ng 3', '^(.*?)1(?=(2))??.*x1(?=\2)',   '.12...1a...x12',  [1,13, 1,1, 3,1]);
+  // * vs *?
+  IsMatching('look-ahead-opt-ng 1', '^(.*?)1(?=(2))*.*x1(?=\2)?',   '.12...1a...x12',  [1,13, 1,1, 3,1]);
+  IsMatching('look-ahead-opt-ng 2', '^(.*?)1(?=(2))*?.*x1(?=\2)?',   '.12...1a...x12',  [1,13, 1,1, -1,-1]);
+  IsMatching('look-ahead-opt-ng 3', '^(.*?)1(?=(2))*?.*x1(?=\2)',   '.12...1a...x12',  [1,13, 1,1, 3,1]);
+  // {0,1} vs {0,1}?
+  IsMatching('look-ahead-opt-ng 1', '^(.*?)1(?=(2)){0,1}.*x1(?=\2)?',   '.12...1a...x12',  [1,13, 1,1, 3,1]);
+  IsMatching('look-ahead-opt-ng 2', '^(.*?)1(?=(2)){0,1}?.*x1(?=\2)?',   '.12...1a...x12',  [1,13, 1,1, -1,-1]);
+  IsMatching('look-ahead-opt-ng 3', '^(.*?)1(?=(2)){0,1}?.*x1(?=\2)',   '.12...1a...x12',  [1,13, 1,1, 3,1]);
+
+
+  // PCRE-2 will apply a look ahead several times...
+  IsMatching('look-ahead match-count',  '(?=(?=.*(?:\1|a)(.))|$){1,3}', '1234567890abcdefghi',   [1,0,  14,1]);
+  IsMatching('look-ahead match-count',  '(?=(?=.*(?:\1|a)(.))|$){1,4}', '1234567890abcdefghi',   [1,0,  15,1]);
+  IsMatching('look-ahead match-count',  '(?=(?=.*(?:\1|a)(.))|$){1,4}?', '1234567890abcdefghi',   [1,0,  12,1]);
+  IsMatching('look-ahead match-count',  '(?=(?=.*(?:\1|a)(.))|$){2,4}?', '1234567890abcdefghi',   [1,0,  13,1]);
+
+  IsMatching('look-ahead match-count',  '(?=(?:.*(?:\1|a)(.))|$){1,3}', '1234567890abcdefghi',   [1,0,  14,1]);
+  IsMatching('look-ahead match-count',  '(?=(?:.*(?:\1|a)(.))|$){1,4}', '1234567890abcdefghi',   [1,0,  15,1]);
+  IsMatching('look-ahead match-count',  '(?=(?:.*(?:\1|a)(.))|$){1,4}?', '1234567890abcdefghi',   [1,0,  12,1]);
+  IsMatching('look-ahead match-count',  '(?=(?:.*(?:\1|a)(.))|$){2,4}?', '1234567890abcdefghi',   [1,0,  13,1]);
+
+  // Neg look ahead
+  // ? vs ??
+  IsMatching('NEG look-ahead-opt-ng 1', '^.1((?!(?1))??)',   '.12.',  [1,2, 3,0]);
+//  IsErrorOnMatch('NEG look-ahead-opt-g (recurse)', '^.1((?!(?1))?)',   '.12.'); // OP_SUBCALL does not give error on endless recursion
 end;
 
 procedure TTestRegexpr.TestRegLookBehind;
@@ -2796,6 +2844,43 @@ begin
   IsMatching('look-behind (opt) in branch',     '^.(?:a|.(?<=Y)?|b)',    '.xb9',  [1,2]);
   IsMatching('look-behind-neg (opt) in branch', '^.(?:a|.(?<!.)?|b)',    '.xb9',  [1,2]);
   IsMatching('look-behind-neg in branch',       '^.(?:a|.(?<!Y)|b)',     '.xb9',  [1,2]);
+
+  // possesive optional lookahead
+  // ?+
+  IsMatching('look-behind-poss-opt ?',  '^(.*?)1.(?<=(2))?.*x1(?!\2)',   '.12...1a...x12',  [1,13, 1,1, -1,-1]);
+  IsMatching('look-behind-poss-opt ??', '^(.*?)1.(?<=(2))?+.*x1(?!\2)',  '.12...1a...x12',  [1,13, 1,6, -1,-1]);
+  // *+
+  IsMatching('look-behind-poss-opt *',  '^(.*?)1.(?<=(2))*.*x1(?!\2)',   '.12...1a...x12',  [1,13, 1,1, -1,-1]);
+  IsMatching('look-behind-poss-opt *?', '^(.*?)1.(?<=(2))*+.*x1(?!\2)',  '.12...1a...x12',  [1,13, 1,6, -1,-1]);
+  // {0,1}+
+  IsMatching('look-behind-poss-opt {0,1}',  '^(.*?)1.(?<=(2)){0,1}.*x1(?!\2)',   '.12...1a...x12',  [1,13, 1,1, -1,-1]);
+  IsMatching('look-behind-poss-opt {0,1}+', '^(.*?)1.(?<=(2)){0,1}+.*x1(?!\2)',  '.12...1a...x12',  [1,13, 1,6, -1,-1]);
+  // {0,0}+ // no diff
+  IsMatching('look-ahead-poss-opt {0,0} ', '^(.*?)1.(?<=(2)){0,0}.*x1(?!\2)',  '.12...1a...x12',  [1,13, 1,1, -1,-1]);
+  IsMatching('look-ahead-poss-opt {0,0}+', '^(.*?)1.(?<=(2)){0,0}+.*x1(?!\2)',  '.12...1a...x12',  [1,13, 1,1, -1,-1]);
+  // {1,1}+ // no diff
+  IsNotMatching('look-ahead-poss-opt {1,1} ', '^(.*?)1.(?<=(2)){1,1}.*x1(?!\2)',  '.12...1a...x12');
+  IsNotMatching('look-ahead-poss-opt {1,1}+', '^(.*?)1.(?<=(2)){1,1}+.*x1(?!\2)',  '.12...1a...x12');
+
+  // greedy vs non greedy
+  // ? vs ??
+  IsMatching('look-ahead-opt-ng ? 1', '^(.*?)1.(?<=(2))?.*x1(?=\2)?',   '.12...1a...x12',  [1,13, 1,1, 3,1]);
+  IsMatching('look-ahead-opt-ng ? 2', '^(.*?)1.(?<=(2))??.*x1(?=\2)?',   '.12...1a...x12',  [1,13, 1,1, -1,-1]);
+  IsMatching('look-ahead-opt-ng ? 3', '^(.*?)1.(?<=(2))??.*x1(?=\2)',   '.12...1a...x12',  [1,13, 1,1, 3,1]);
+  // * vs *?
+  IsMatching('look-ahead-opt-ng * 1', '^(.*?)1.(?<=(2))*.*x1(?=\2)?',   '.12...1a...x12',  [1,13, 1,1, 3,1]);
+  IsMatching('look-ahead-opt-ng * 2', '^(.*?)1.(?<=(2))*?.*x1(?=\2)?',   '.12...1a...x12',  [1,13, 1,1, -1,-1]);
+  IsMatching('look-ahead-opt-ng * 3', '^(.*?)1.(?<=(2))*?.*x1(?=\2)',   '.12...1a...x12',  [1,13, 1,1, 3,1]);
+  // {0,1} vs {0,1}?
+  IsMatching('look-ahead-opt-ng {} 1', '^(.*?)1.(?<=(2)){0,1}.*x1(?=\2)?',   '.12...1a...x12',  [1,13, 1,1, 3,1]);
+  IsMatching('look-ahead-opt-ng {} 2', '^(.*?)1.(?<=(2)){0,1}?.*x1(?=\2)?',   '.12...1a...x12',  [1,13, 1,1, -1,-1]);
+  IsMatching('look-ahead-opt-ng {} 3', '^(.*?)1.(?<=(2)){0,1}?.*x1(?=\2)',   '.12...1a...x12',  [1,13, 1,1, 3,1]);
+
+  // PCRE-2 will apply a look ahead several times...
+  IsMatching('look-behind match-count',  '(?<=(?=.*(?:\1|a)(.))|$){1,3}', '1234567890abcdefghi',   [1,0,  14,1]);
+  IsMatching('look-behind match-count',  '(?<=(?=.*(?:\1|a)(.))|$){1,4}', '1234567890abcdefghi',   [1,0,  15,1]);
+  IsMatching('look-behind match-count',  '(?<=(?=.*(?:\1|a)(.))|$){1,4}?', '1234567890abcdefghi',   [1,0,  12,1]);
+  IsMatching('look-behind match-count',  '(?<=(?=.*(?:\1|a)(.))|$){2,4}?', '1234567890abcdefghi',   [1,0,  13,1]);
 end;
 
 procedure TTestRegexpr.TestRegLookAroundMixed;


### PR DESCRIPTION
Fixes and improvements for look-around

`(?=.(capt).)?.*\1` optional look-around was handled incorrectly if it contained code that was later referred.

`(?=...)?+` possessive modifiers on look-around were not handled at all.  

Also ng `??` and loops if they affected captures.

----

Last commit is a tiny optimization for speed. (under fpc / but shouldn't hurt any other compiler)