### PR TITLE
Opt matchprim

### DIFF
--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -5438,7 +5438,6 @@ var
   nextch: REChar;
   BracesMin, BracesMax: Integer;
   // we use integer instead of TREBracesArg to better support */+
-  bound1, bound2: Boolean;
   Local: TRegExprMatchPrimLocals;
 begin
   Result := False;
@@ -5466,17 +5465,19 @@ begin
     case scan^ of
       OP_BOUND:
         begin
-          bound1 := (regInput = fInputStart) or not IsWordChar((regInput - 1)^);
-          bound2 := (regInput >= fInputEnd) or not IsWordChar(regInput^);
-          if bound1 = bound2 then
+          if ( (regInput = fInputStart) or not IsWordChar((regInput - 1)^) )
+             =
+             ( (regInput >= fInputEnd)  or not IsWordChar(regInput^) )
+          then
             Exit;
         end;
 
       OP_NOTBOUND:
         begin
-          bound1 := (regInput = fInputStart) or not IsWordChar((regInput - 1)^);
-          bound2 := (regInput >= fInputEnd) or not IsWordChar(regInput^);
-          if bound1 <> bound2 then
+          if ( (regInput = fInputStart) or not IsWordChar((regInput - 1)^) )
+             <>
+             ( (regInput >= fInputEnd)  or not IsWordChar(regInput^) )
+          then
             Exit;
         end;
 
@@ -6418,12 +6419,13 @@ begin
           begin
             Inc(regRecursion);
             FillChar(GrpBounds[regRecursion].GrpStart[0], SizeOf(GrpBounds[regRecursion].GrpStart[0])*regNumBrackets, 0);
-            bound1 := MatchPrim(regCodeWork);
+            Result := MatchPrim(regCodeWork);
             Dec(regRecursion);
+            if not Result then Exit;
+            Result := False;
           end
           else
-            bound1 := False;
-          if not bound1 then Exit;
+            Exit;
         end;
 
       OP_SUBCALL:
@@ -6440,13 +6442,14 @@ begin
             CurrentSubCalled := no;
             Inc(regRecursion);
             FillChar(GrpBounds[regRecursion].GrpStart[0], SizeOf(GrpBounds[regRecursion].GrpStart[0])*regNumBrackets, 0);
-            bound1 := MatchPrim(save);
+            Result := MatchPrim(save);
             Dec(regRecursion);
             CurrentSubCalled := Local.savedCurrentSubCalled;
+            if not Result then Exit;
+            Result := False;
           end
           else
-            bound1 := False;
-          if not bound1 then Exit;
+            Exit;
         end;
 
       OP_ANYLINEBREAK:

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -6282,37 +6282,26 @@ begin
 
       OP_STAR_POSS, OP_PLUS_POSS, OP_BRACES_POSS:
         begin
-          // Lookahead to avoid useless match attempts when we know
-          // what character comes next.
-          nextch := #0;
-          if next^ = OP_EXACTLY then
-            nextch := (next + REOpSz + RENextOffSz + RENumberSz)^;
           opnd := scan + REOpSz + RENextOffSz;
           case scan^ of
             OP_STAR_POSS:
               begin
-                BracesMin := 0;
-                BracesMax := MaxInt;
+                FindRepeated(opnd, MaxInt);
               end;
             OP_PLUS_POSS:
               begin
-                BracesMin := 1;
-                BracesMax := MaxInt;
+                if FindRepeated(opnd, MaxInt) < 1 then
+                  Exit;
               end;
             else
               begin // braces
-                BracesMin := PREBracesArg(AlignToPtr(scan + REOpSz + RENextOffSz))^;
-                BracesMax := PREBracesArg(AlignToPtr(scan + REOpSz + RENextOffSz + REBracesArgSz))^;
-                Inc(opnd, 2 * REBracesArgSz);
+                opnd := AlignToPtr(opnd);
+                if FindRepeated(opnd + 2 * REBracesArgSz, PREBracesArg(opnd + REBracesArgSz)^)
+                   < PREBracesArg(opnd)^
+                then
+                  Exit;
               end;
           end;
-          no := FindRepeated(opnd, BracesMax);
-          if no >= BracesMin then
-            if (nextch = #0) or (regInput^ = nextch) then begin
-              scan := next;
-              continue;
-            end;
-          Exit;
         end;
 
       OP_EEND:

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -7425,6 +7425,7 @@ begin
           Include(FirstCharSet, Byte($0B));
           Include(FirstCharSet, Byte($0C));
           Include(FirstCharSet, Byte($85));
+          Exit;
         end;
 
     else

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -5033,7 +5033,7 @@ begin
   Result := 0;
   scan := regInput; // points into InputString
   opnd := p + REOpSz + RENextOffSz; // points to operand of opcode (after OP_nnn code)
-  TheMax := fInputEnd - scan;
+  TheMax := fInputCurrentEnd - scan;
   if TheMax > AMax then
     TheMax := AMax;
   case PREOp(p)^ of

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -5724,13 +5724,18 @@ begin
           opGrpEnd := GrpBounds[regRecursion].GrpEnd[no];
           if opGrpEnd = nil then
             Exit;
+          no := opGrpEnd - opnd;
           save := regInput;
-          while opnd < opGrpEnd do
+          if save + no - 1 >= fInputCurrentEnd then
+            Exit;
+
+          while no > 0 do
           begin
-            if (save >= fInputCurrentEnd) or (save^ <> opnd^) then
+            if (save^ <> opnd^) then
               Exit;
             Inc(save);
             Inc(opnd);
+            Dec(no);
           end;
           regInput := save;
         end;
@@ -5747,14 +5752,18 @@ begin
           opGrpEnd := GrpBounds[regRecursion].GrpEnd[no];
           if opGrpEnd = nil then
             Exit;
+          no := opGrpEnd - opnd;
           save := regInput;
-          while opnd < opGrpEnd do
+          if save + no - 1 >= fInputCurrentEnd then
+            Exit;
+
+          while no > 0 do
           begin
-            if (save >= fInputCurrentEnd) or
-              ((save^ <> opnd^) and (save^ <> InvertCase(opnd^))) then
+            if ((save^ <> opnd^) and (save^ <> InvertCase(opnd^))) then
               Exit;
             Inc(save);
             Inc(opnd);
+            Dec(no);
           end;
           regInput := save;
         end;

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -4652,7 +4652,6 @@ begin
               if fSecondPass and (Len < 0) then
                 Error(reeNamedGroupBadRef);
               ret := EmitGroupRef(Len, fCompModifiers.I);
-              FlagParse := FlagParse or FLAG_HASWIDTH or FLAG_SIMPLE;
             end;
 
           gkModifierString:
@@ -4820,7 +4819,6 @@ begin
               if fSecondPass and (Ord(regParse^) - Ord('0') > GrpCount) then
                 Error(reeBadReference);
               ret := EmitGroupRef(Ord(regParse^) - Ord('0'), fCompModifiers.I);
-              FlagParse := FlagParse or FLAG_HASWIDTH or FLAG_SIMPLE;
             end;
           'g':
             begin
@@ -4848,7 +4846,6 @@ begin
                     if fSecondPass and  (GrpIndex < 1) then
                       Error(reeNamedGroupBadRef);
                     ret := EmitGroupRef(GrpIndex, fCompModifiers.I);
-                    FlagParse := FlagParse or FLAG_HASWIDTH or FLAG_SIMPLE;
                   end;
                 '0'..'9':
                   begin
@@ -4863,7 +4860,6 @@ begin
                     if fSecondPass and (GrpIndex > GrpCount) then
                       Error(reeBadReference);
                     ret := EmitGroupRef(GrpIndex, fCompModifiers.I);
-                    FlagParse := FlagParse or FLAG_HASWIDTH or FLAG_SIMPLE;
                   end;
               else
                 Error(reeBadReference);
@@ -4887,7 +4883,6 @@ begin
               if fSecondPass and (GrpIndex < 1) then
                 Error(reeNamedGroupBadRef);
               ret := EmitGroupRef(GrpIndex, fCompModifiers.I);
-              FlagParse := FlagParse or FLAG_HASWIDTH or FLAG_SIMPLE;
             end;
           'K':
             begin
@@ -5031,8 +5026,6 @@ var
   opnd: PRegExprChar;
   TheMax: PtrInt; // PtrInt, gets diff of 2 pointers
   InvChar: REChar;
-  CurStart, CurEnd: PRegExprChar;
-  ArrayIndex: Integer;
   {$IFDEF UnicodeEx}
   i: Integer;
   {$ENDIF}
@@ -5096,57 +5089,6 @@ begin
             Inc(scan);
           end;
         end;
-      end;
-
-    OP_BSUBEXP:
-      begin
-        ArrayIndex := GrpIndexes[PReGroupIndex(opnd)^];
-        if ArrayIndex < 0 then
-          Exit;
-        CurStart := GrpBounds[regRecursion].GrpStart[ArrayIndex];
-        if CurStart = nil then
-          Exit;
-        CurEnd := GrpBounds[regRecursion].GrpEnd[ArrayIndex];
-        if CurEnd = nil then
-          Exit;
-        repeat
-          opnd := CurStart;
-          while opnd < CurEnd do
-          begin
-            if (scan >= fInputEnd) or (scan^ <> opnd^) then
-              Exit;
-            Inc(scan);
-            Inc(opnd);
-          end;
-          Inc(Result);
-          regInput := scan;
-        until Result >= AMax;
-      end;
-
-    OP_BSUBEXP_CI:
-      begin
-        ArrayIndex := GrpIndexes[PReGroupIndex(opnd)^];
-        if ArrayIndex < 0 then
-          Exit;
-        CurStart := GrpBounds[regRecursion].GrpStart[ArrayIndex];
-        if CurStart = nil then
-          Exit;
-        CurEnd := GrpBounds[regRecursion].GrpEnd[ArrayIndex];
-        if CurEnd = nil then
-          Exit;
-        repeat
-          opnd := CurStart;
-          while opnd < CurEnd do
-          begin
-            if (scan >= fInputEnd) or
-              ((scan^ <> opnd^) and (scan^ <> InvertCase(opnd^))) then
-              Exit;
-            Inc(scan);
-            Inc(opnd);
-          end;
-          Inc(Result);
-          regInput := scan;
-        until Result >= AMax;
       end;
 
     OP_ANYDIGIT:

--- a/test/tests.pas
+++ b/test/tests.pas
@@ -72,6 +72,7 @@ type
     procedure TestBads;
     procedure TestModifiers;
     procedure TestContinueAnchor;
+    procedure TestLineBreak;
     procedure TestRegMustExist;
     procedure TestAtomic;
     procedure TestQuesitonMark;
@@ -1142,6 +1143,22 @@ begin
   RE.InputString:= '_A123X3';
   IsTrue('Exec must give True', RE.Exec(2));
   AssertMatch('(?<=^.\GA...)(X)  _A123X3 offset 2 ', 6, 1);
+end;
+
+procedure TTestRegexpr.TestLineBreak;
+begin
+  IsNotMatching('no linebreak (stand alone)', '\R', 'abcd');
+  IsMatching('no linebreak (stand alone / loop)', '\R*', 'abcd', [1,0]);
+
+  IsMatching('no loop linebreak', 'a\Rb', 'a'#13'b',      [1,3] );
+  IsMatching('no loop linebreak', 'a\Rb', 'a'#10'b',      [1,3] );
+  IsMatching('no loop linebreak', 'a\Rb', 'a'#13#10'b',   [1,4] );
+  IsMatching('loop linebreak', 'a\R*b', 'a'#13'b',      [1,3] );
+  IsMatching('loop linebreak', 'a\R*b', 'a'#10'b',      [1,3] );
+  IsMatching('loop linebreak', 'a\R*b', 'a'#13#10'b',   [1,4] );
+
+  IsNotMatching('no loop linebreak', 'a\R\Rb', 'a'#13#10'b');
+//  IsNotMatching('   loop linebreak', 'a\R+\Rb', 'a'#13#10'b');
 end;
 
 procedure TTestRegexpr.TestRegMustExist;

--- a/test/tests.pas
+++ b/test/tests.pas
@@ -2885,6 +2885,9 @@ begin
   IsMatching('look-behind match-count',  '(?<=(?=.*(?:\1|a)(.))|$){1,4}', '1234567890abcdefghi',   [1,0,  15,1]);
   IsMatching('look-behind match-count',  '(?<=(?=.*(?:\1|a)(.))|$){1,4}?', '1234567890abcdefghi',   [1,0,  12,1]);
   IsMatching('look-behind match-count',  '(?<=(?=.*(?:\1|a)(.))|$){2,4}?', '1234567890abcdefghi',   [1,0,  13,1]);
+
+
+  IsMatching('look-behind op-star',  '^aa(?<=^(a*))', 'aaaaaa',   [1,2,  1,2]);
 end;
 
 procedure TTestRegexpr.TestRegLookAroundMixed;

--- a/test/tests.pas
+++ b/test/tests.pas
@@ -1789,6 +1789,17 @@ begin
 
   IsMatching('ref in branch', '((A)|B|C\2)*',  'AACACB',  [1,4,  3,2, 2,1]);
   IsMatching('ref in call', '[^A]*((A)|B|C\2)*',  'DAACACBE',  [1,5,  4,2, 3,1]);
+
+
+  IsMatching('ref in branch', '(...).\1',  'abcxabc',  [1,7,  1,3]);
+  IsNotMatching('ref in branch', '(...).\1',  'abcxab');
+  CompileRE('(...).\1');
+  RE.SetInputSubString('abcxabc', 1,7);
+  IsTrue('Matches on full string', RE.Exec);
+  CompileRE('(...).\1');
+  RE.SetInputSubString('abcxabc', 1,6);
+  IsFalse('Does NOT match on short string', RE.Exec);
+
 end;
 
 procedure TTestRegexpr.TestSubCall;

--- a/test/tests.pas
+++ b/test/tests.pas
@@ -1517,6 +1517,10 @@ begin
              'AayyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyBB',   [1,44,   -1,-1, -1,-1, -1,-1] ); // 40 y
 
 
+  IsMatching('loop group-ref', '^(123)\1*1..a', '123123123abcde',   [1,10,   1,3] );
+  IsNotMatching('loop group-ref (empty)', '(\b)\1*3', '.. test 2345' );
+  IsMatching('loop group-ref (empty)', '(\b)\1*.*3', '.. test 2345',   [4,7,   4,0] );
+
 end;
 
 procedure TTestRegexpr.TestEmptyLoop;


### PR DESCRIPTION
Some rather small speed improvements.

Fix for #373 

Some added tests.

----

On Reducing local vars:

In smaller routines this sometimes help fpc to improve register allocation, and produce faster code.

In MatchPrim (maybe due to it's size) this is not always the case. Or maybe it has side-effects to to code-alignment of subsequent code in the proc.

Moving vars to the "Local" record is probably only good for some of the big blocks specific to just one OP. It may be that Fpc is not using registers for fields of a record (though I have not verified that, more of a guess).
But especially when the loop/look around anyway use there own records those can/should be in the "Local".
