### PR TITLE
Small optimization / Needs testing with Delphi

### DIFF
--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -4509,7 +4509,6 @@ begin
             'a'..'z', '-':
               begin
                 // modifiers string like (?mxr)
-                FlagParse := FlagParse or FLAG_NOT_QUANTIFIABLE;
                 GrpKind := gkModifierString;
                 Inc(regParse);
               end;
@@ -4696,6 +4695,7 @@ begin
               begin
                 Inc(regParse); // skip ')'
                 ret := EmitNode(OP_COMMENT); // comment
+                FlagParse := FlagParse or FLAG_NOT_QUANTIFIABLE;
               end
               else
               begin

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -6796,7 +6796,7 @@ begin
     repeat
       Inc(Ptr);
       if Ptr > SearchEnd then
-        Exit;
+        Break;
 
       {$IFDEF UseFirstCharSet}
       {$IFDEF UnicodeRE}
@@ -6811,6 +6811,11 @@ begin
       if Result then
         Exit;
     until False;
+
+    {$IFDEF UseFirstCharSet}
+      if FirstCharArray[0] and (fInputEnd^ <> #0) then
+        Result := MatchAtOnePos(fInputEnd);
+    {$ENDIF}
   end;
 end; { of function TRegExpr.ExecPrim
   -------------------------------------------------------------- }

--- a/src/regexpr.pas
+++ b/src/regexpr.pas
@@ -6682,11 +6682,10 @@ begin
       except
         on E: ERegExpr do begin
           Result := False;
-          raise;
         end;
         else begin
+          Result := False;
           fLastError := reeUnknown;
-          Error(reeUnknown);
         end;
       end;
     end;
@@ -6727,15 +6726,13 @@ begin
       on E: EStackOverflow do begin
         Result := False;
         fLastError := reeLoopStackExceeded;
-        Error(reeLoopStackExceeded);
       end;
       on E: ERegExpr do begin
         Result := False;
-        raise;
       end;
       else begin
+        Result := False;
         fLastError := reeUnknown;
-        Error(reeUnknown);
       end;
     end;
   end;

--- a/test/tests.pas
+++ b/test/tests.pas
@@ -2262,6 +2262,14 @@ begin
   end;
 
 
+  CompileRE('$');
+  RE.SetInputSubString('abcxabc', 1,7);
+  IsTrue('Matches on full string', RE.Exec);
+
+  CompileRE('$');
+  RE.SetInputSubString('abcxabc', 2,3);
+  IsTrue('Matches on sub-string', RE.Exec);
+
 end;
 
 procedure TTestRegexpr.TestRegLookAhead;

--- a/test/tests.pas
+++ b/test/tests.pas
@@ -1026,6 +1026,9 @@ begin
   IsMatching   ('CaseSens On/Off (?i:B)',   '(?i)A(?-i:B)C',     '1aBc',     [2,3]);
   IsNotMatching('CaseSens On/Off (?i:B)',   '(?i)A(?-i:B)C',     '1abc');
 
+
+  IsMatching   ('CaseSens On/Off (?i:B)+',   '(?i)A(?-i:B)+C',     '1aBBBc',     [2,5]);
+  IsNotMatching   ('CaseSens On/Off (?i:B)+',   '(?i)A(?-i:B)+C',     '1aBbBc');
 end;
 
 procedure TTestRegexpr.TestContinueAnchor;


### PR DESCRIPTION
The first commit is ready to go. Just skipping unnecessary mem alloc.

----

**The 2nd commit 6438a0 needs some testing with Delphi.**

It replaces `GrpBounds[regRecursion].GrpStart` with direct pointe access. Skipping the need to calculate the element for `regRecursion` (which in 99% of cases is zero anyway).

On my PC, the benchmark gains 2%  // Real live apps gain less, but still.

I know Delphi should have "PointerMath". I don't know if it is the same compiler directive. And I don't know if it works 100% identical. So that needs testing.

I tried to just use an `array of PRegExprChar` instead of `^PRegExprChar`. But that slowed things down. It adds refcounts, and then, if one array is resized, the other isn't...

The pointers are safe. They are only used in MatchPrim. Nothing can change the underlying arrays during the run. And `ClearInternalExecData` ensures the value are valid at start.
Data is still stored in the array, and any access outside MatchPrim reads it from the arrays, and not via the pointers.