### PR TITLE
Backwards kompatible with D7

### DIFF
--- a/test/test_delphid7.dpr
+++ b/test/test_delphid7.dpr
@@ -1,0 +1,28 @@
+program test_delphid7;
+
+uses
+  FastMM4 in '..\..\..\fastMM\FastMM4.pas',
+  SysUtils,
+  TestFramework,
+  TestExtensions,
+  Forms,
+  GUITestRunner,
+  TextTestRunner,
+  GUITesting,
+  tests in 'tests.pas',
+  regexpr in '..\..\Regexpr.pas';
+
+{$R *.res}
+
+
+begin
+  if FindCmdLineSwitch('text-mode', ['-','/'], true) then
+    TextTestRunner.RunRegisteredTests(rxbHaltOnFailures)
+  else
+  begin
+    Application.Initialize;
+    Application.Title := 'DUnit Tests';
+    // RunRegisteredTests class methods are recommended
+    TGUITestRunner.RunRegisteredTests;
+  end;
+end.


### PR DESCRIPTION
- Main change is: accessing an array via pointer is not supported - therefore 2 helper functions need.
- Tests project based on old DUnit is added 
-- some tests, which cannot succeed are excluded due to missing "FastUnicodeData"
-- Test73/74 fail - reason not inspected - other test succeeded.